### PR TITLE
Fix problems with indexed and overlapping registers.

### DIFF
--- a/src/base_types.adb
+++ b/src/base_types.adb
@@ -614,16 +614,16 @@ package body Base_Types is
          exit when Element (Name1, J) not in '0' .. '9';
       end loop;
 
+      if Prefix > Length (Name2) then
+         return Null_Unbounded_String;
+      end if;
+
       if Element (Name1, Prefix) = '_'
         and then Element (Name2, Prefix) = '_'
       then
          --  We have names of the form PREFIX_XXXX
          --  In this case, we also strip the '_' character
          Prefix := Prefix - 1;
-      end if;
-
-      if Prefix > Length (Name2) then
-         return Null_Unbounded_String;
       end if;
 
       if Slice (Name1, 1, Prefix) /= Slice (Name2, 1, Prefix) then

--- a/src/descriptors-peripheral.adb
+++ b/src/descriptors-peripheral.adb
@@ -261,14 +261,16 @@ package body Descriptors.Peripheral is
                Prefix : constant String := To_String (Reg.Name);
             begin
                Last := Prefix'Last;
-               --  First loop: look of another register at the same offset
+               --  First loop: look at another register at the same offset
                --  If found, mark the current register as overlapping, and find
                --  a prefix common to all overlapping registers.
                for K in Idx + 1 .. Reg_Set.Last_Index loop
                   exit when Reg_Set (K).Address_Offset /= Reg.Address_Offset;
 
                   for J in 1 .. Last loop
-                     if Prefix (J) /= Element (Reg_Set (K).Name, J) then
+                     if J > Length (Reg_Set (K).Name)
+                       or else Prefix (J) /= Element (Reg_Set (K).Name, J)
+                     then
                         if Last /= 0 then
                            Last := J - 1;
                         end if;
@@ -303,8 +305,18 @@ package body Descriptors.Peripheral is
                      Reg.Overlap_Suffix := To_Unbounded_String ("Default");
 
                   else
-                     Reg.Overlap_Suffix :=
-                       To_Unbounded_String (Prefix (Last + 1 .. Prefix'Last));
+                     --  If we have names like "CMR0",
+                     --  "CMR0_WAVE_EQ_1", the suffix for the second must
+                     --  skip the '_'.
+                     declare
+                        Skip : Positive := Last + 1;
+                     begin
+                        while Prefix (Skip) = '_' loop
+                           Skip := Skip + 1;
+                        end loop;
+                        Reg.Overlap_Suffix :=
+                          To_Unbounded_String (Prefix (Skip .. Prefix'Last));
+                     end;
                   end if;
 
                   Idx := Idx + 1;


### PR DESCRIPTION
- src/base_types.adb (Common_Prefix): Check for the proposed prefix
    being longer than the second name before checking the second name.
- src/descriptors-peripheral.adb (Find_Overlapping_Registers): Check
    the length of the Kth name before checking for character equality.
    Avoid starting Overlap_Suffix with an underscore.
