### PR TITLE
Remove Short and Word special case for unsigned 16 and 32

### DIFF
--- a/src/base_types.adb
+++ b/src/base_types.adb
@@ -47,10 +47,6 @@ package body Base_Types is
          return Pkg & "Bit";
       elsif Size = 8 then
          return Pkg & "Byte";
-      elsif Size = 16 then
-         return Pkg & "Short";
-      elsif Size = 32 then
-         return Pkg & "Word";
       else
          return Pkg & "UInt" & To_String (Size);
       end if;


### PR DESCRIPTION
The use of Word and Short to designate data type is ambiguous, not only
they do not express the signed or unsigned nature of the type, the size
is also different depending on the architecture. Using UInt32 and UInt16
is also more coherent with the other unsigned integer types generated.
