### PR TITLE
UInt8|16|32 as derived type instead of subtypes 

### DIFF
--- a/src/ada_gen.adb
+++ b/src/ada_gen.adb
@@ -411,8 +411,8 @@ package body Ada_Gen is
         or else Element.Size = 64
       then
          Ada.Text_IO.Put_Line
-           (File, "   subtype " & To_String (Element.Id) &
-              " is Interfaces.Unsigned_" & To_String (Element.Size) & ";");
+           (File, "   type " & To_String (Element.Id) &
+              " is new Interfaces.Unsigned_" & To_String (Element.Size) & ";");
       else
          Ada.Text_IO.Put
            (File, "   type " & To_String (Element.Id) &

--- a/src/base_types.adb
+++ b/src/base_types.adb
@@ -43,7 +43,11 @@ package body Base_Types is
                else SVD2Ada_Utils.Base_Types_Package & ".");
 
    begin
-      return Pkg & "UInt" & To_String (Size);
+      if Size = 1 then
+         return Pkg & "Bit";
+      else
+         return Pkg & "UInt" & To_String (Size);
+      end if;
    end Target_Type;
 
    ---------

--- a/src/base_types.adb
+++ b/src/base_types.adb
@@ -43,13 +43,7 @@ package body Base_Types is
                else SVD2Ada_Utils.Base_Types_Package & ".");
 
    begin
-      if Size = 1 then
-         return Pkg & "Bit";
-      elsif Size = 8 then
-         return Pkg & "Byte";
-      else
-         return Pkg & "UInt" & To_String (Size);
-      end if;
+      return Pkg & "UInt" & To_String (Size);
    end Target_Type;
 
    ---------


### PR DESCRIPTION
This way it is not necessary to use the Interfaces package when manipulating values of those types.