### PR TITLE
STM32F40x and STM32F429x SVD: Reuse STM32F469 description of SDIO

### DIFF
--- a/CMSIS-SVD/ST/STM32F40x.svd
+++ b/CMSIS-SVD/ST/STM32F40x.svd
@@ -11399,7 +11399,7 @@ xs:noNamespaceSchemaLocation="CMSIS-SVD_Schema_1_1.xsd">
         <usage>registers</usage>
       </addressBlock>
       <interrupt>
-        <name>SDIO_IRQ</name>
+        <name>SDIO</name>
         <description>SDIO global interrupt</description>
         <value>49</value>
       </interrupt>
@@ -11418,6 +11418,18 @@ xs:noNamespaceSchemaLocation="CMSIS-SVD_Schema_1_1.xsd">
               <description>PWRCTRL</description>
               <bitOffset>0</bitOffset>
               <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>Power_OFF</name>
+                  <description>The clock to card is stopped.</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Power_ON</name>
+                  <description>The card is clocked.</description>
+                  <value>3</value>
+                </enumeratedValue>
+              </enumeratedValues>
             </field>
           </fields>
         </register>
@@ -11442,12 +11454,41 @@ xs:noNamespaceSchemaLocation="CMSIS-SVD_Schema_1_1.xsd">
               bit</description>
               <bitOffset>13</bitOffset>
               <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>Edge_Rising</name>
+                  <description>Cmd and Data changed on the SDMMCCLK falling edge succeeding the rising edge of SDMMC_CK.</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Edge_Falling</name>
+                  <description>Cmd and Data changed on the SDMMC_CK falling edge.</description>
+                  <value>1</value>
+                </enumeratedValue>
+              </enumeratedValues>
             </field>
             <field>
               <name>WIDBUS</name>
               <description>Wide bus mode enable bit</description>
               <bitOffset>11</bitOffset>
               <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>Bus_Wide_1b</name>
+                  <description>Default bus mode: SDMMC_D0 is used.</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Bus_Wide_4b</name>
+                  <description>4-wide bus mode: SDMMC_D[3:0] used.</description>
+                  <value>1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Bus_Wide_8b</name>
+                  <description>8-wide bus mode: SDMMC_D[7:0] used.</description>
+                  <value>2</value>
+                </enumeratedValue>
+              </enumeratedValues>
             </field>
             <field>
               <name>BYPASS</name>
@@ -11553,6 +11594,23 @@ xs:noNamespaceSchemaLocation="CMSIS-SVD_Schema_1_1.xsd">
               <description>Wait for response bits</description>
               <bitOffset>6</bitOffset>
               <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>No_Response</name>
+                  <description>No response, expect CMDSENT flag.</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Short_Response</name>
+                  <description>Short response, expect CMDREND or CCRCFAIL flag.</description>
+                  <value>1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Long_Response</name>
+                  <description>Long response, expect CMDREND or CCRCFAIL flag.</description>
+                  <value>3</value>
+                </enumeratedValue>
+              </enumeratedValues>
             </field>
             <field>
               <name>CMDINDEX</name>
@@ -11719,6 +11777,83 @@ xs:noNamespaceSchemaLocation="CMSIS-SVD_Schema_1_1.xsd">
               <description>Data block size</description>
               <bitOffset>4</bitOffset>
               <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>Block_1b</name>
+                  <description>Block length = 2**0 = 1 byte</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Block_2b</name>
+                  <description>Block length = 2**1 = 2 byte</description>
+                  <value>1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Block_4b</name>
+                  <description>Block length = 2**2 = 4 byte</description>
+                  <value>2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Block_8b</name>
+                  <description>Block length = 2**3 = 8 byte</description>
+                  <value>3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Block_16b</name>
+                  <description>Block length = 2**4 = 16 byte</description>
+                  <value>4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Block_32b</name>
+                  <description>Block length = 2**5 = 32 byte</description>
+                  <value>5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Block_64b</name>
+                  <description>Block length = 2**6 = 64 byte</description>
+                  <value>6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Block_128b</name>
+                  <description>Block length = 2**7 = 128 byte</description>
+                  <value>7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Block_256b</name>
+                  <description>Block length = 2**8 = 256 byte</description>
+                  <value>8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Block_512b</name>
+                  <description>Block length = 2**9 = 512 byte</description>
+                  <value>9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Block_1024b</name>
+                  <description>Block length = 2**10 = 1024 byte</description>
+                  <value>10</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Block_2048b</name>
+                  <description>Block length = 2**11 = 2048 byte</description>
+                  <value>11</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Block_4096b</name>
+                  <description>Block length = 2**12 = 4096 byte</description>
+                  <value>12</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Block_8192b</name>
+                  <description>Block length = 2**13 = 8192 byte</description>
+                  <value>13</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Block_16384b</name>
+                  <description>Block length = 2**14 = 16384 byte</description>
+                  <value>14</value>
+                </enumeratedValue>
+              </enumeratedValues>
             </field>
             <field>
               <name>DMAEN</name>
@@ -11732,6 +11867,18 @@ xs:noNamespaceSchemaLocation="CMSIS-SVD_Schema_1_1.xsd">
               or SDIO multibyte data transfer.</description>
               <bitOffset>2</bitOffset>
               <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>Block</name>
+                  <description>Block data transfer</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Stream</name>
+                  <description>Stream or SDIO multibyte data transfer</description>
+                  <value>1</value>
+                </enumeratedValue>
+              </enumeratedValues>
             </field>
             <field>
               <name>DTDIR</name>
@@ -11739,6 +11886,18 @@ xs:noNamespaceSchemaLocation="CMSIS-SVD_Schema_1_1.xsd">
               selection</description>
               <bitOffset>1</bitOffset>
               <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>Controller_To_Card</name>
+                  <description>Data is sent to the card</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Card_To_Controller</name>
+                  <description>Data is read from the card</description>
+                  <value>1</value>
+                </enumeratedValue>
+              </enumeratedValues>
             </field>
             <field>
               <name>DTEN</name>

--- a/CMSIS-SVD/ST/STM32F429x.svd
+++ b/CMSIS-SVD/ST/STM32F429x.svd
@@ -12100,7 +12100,7 @@ xs:noNamespaceSchemaLocation="CMSIS-SVD_Schema_1_1.xsd">
         <usage>registers</usage>
       </addressBlock>
       <interrupt>
-        <name>SDIO_IRQ</name>
+        <name>SDIO</name>
         <description>SDIO global interrupt</description>
         <value>49</value>
       </interrupt>
@@ -12119,6 +12119,18 @@ xs:noNamespaceSchemaLocation="CMSIS-SVD_Schema_1_1.xsd">
               <description>PWRCTRL</description>
               <bitOffset>0</bitOffset>
               <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>Power_OFF</name>
+                  <description>The clock to card is stopped.</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Power_ON</name>
+                  <description>The card is clocked.</description>
+                  <value>3</value>
+                </enumeratedValue>
+              </enumeratedValues>
             </field>
           </fields>
         </register>
@@ -12143,12 +12155,41 @@ xs:noNamespaceSchemaLocation="CMSIS-SVD_Schema_1_1.xsd">
               bit</description>
               <bitOffset>13</bitOffset>
               <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>Edge_Rising</name>
+                  <description>Cmd and Data changed on the SDMMCCLK falling edge succeeding the rising edge of SDMMC_CK.</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Edge_Falling</name>
+                  <description>Cmd and Data changed on the SDMMC_CK falling edge.</description>
+                  <value>1</value>
+                </enumeratedValue>
+              </enumeratedValues>
             </field>
             <field>
               <name>WIDBUS</name>
               <description>Wide bus mode enable bit</description>
               <bitOffset>11</bitOffset>
               <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>Bus_Wide_1b</name>
+                  <description>Default bus mode: SDMMC_D0 is used.</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Bus_Wide_4b</name>
+                  <description>4-wide bus mode: SDMMC_D[3:0] used.</description>
+                  <value>1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Bus_Wide_8b</name>
+                  <description>8-wide bus mode: SDMMC_D[7:0] used.</description>
+                  <value>2</value>
+                </enumeratedValue>
+              </enumeratedValues>
             </field>
             <field>
               <name>BYPASS</name>
@@ -12254,6 +12295,23 @@ xs:noNamespaceSchemaLocation="CMSIS-SVD_Schema_1_1.xsd">
               <description>Wait for response bits</description>
               <bitOffset>6</bitOffset>
               <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>No_Response</name>
+                  <description>No response, expect CMDSENT flag.</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Short_Response</name>
+                  <description>Short response, expect CMDREND or CCRCFAIL flag.</description>
+                  <value>1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Long_Response</name>
+                  <description>Long response, expect CMDREND or CCRCFAIL flag.</description>
+                  <value>3</value>
+                </enumeratedValue>
+              </enumeratedValues>
             </field>
             <field>
               <name>CMDINDEX</name>
@@ -12420,6 +12478,83 @@ xs:noNamespaceSchemaLocation="CMSIS-SVD_Schema_1_1.xsd">
               <description>Data block size</description>
               <bitOffset>4</bitOffset>
               <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>Block_1b</name>
+                  <description>Block length = 2**0 = 1 byte</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Block_2b</name>
+                  <description>Block length = 2**1 = 2 byte</description>
+                  <value>1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Block_4b</name>
+                  <description>Block length = 2**2 = 4 byte</description>
+                  <value>2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Block_8b</name>
+                  <description>Block length = 2**3 = 8 byte</description>
+                  <value>3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Block_16b</name>
+                  <description>Block length = 2**4 = 16 byte</description>
+                  <value>4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Block_32b</name>
+                  <description>Block length = 2**5 = 32 byte</description>
+                  <value>5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Block_64b</name>
+                  <description>Block length = 2**6 = 64 byte</description>
+                  <value>6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Block_128b</name>
+                  <description>Block length = 2**7 = 128 byte</description>
+                  <value>7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Block_256b</name>
+                  <description>Block length = 2**8 = 256 byte</description>
+                  <value>8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Block_512b</name>
+                  <description>Block length = 2**9 = 512 byte</description>
+                  <value>9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Block_1024b</name>
+                  <description>Block length = 2**10 = 1024 byte</description>
+                  <value>10</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Block_2048b</name>
+                  <description>Block length = 2**11 = 2048 byte</description>
+                  <value>11</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Block_4096b</name>
+                  <description>Block length = 2**12 = 4096 byte</description>
+                  <value>12</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Block_8192b</name>
+                  <description>Block length = 2**13 = 8192 byte</description>
+                  <value>13</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Block_16384b</name>
+                  <description>Block length = 2**14 = 16384 byte</description>
+                  <value>14</value>
+                </enumeratedValue>
+              </enumeratedValues>
             </field>
             <field>
               <name>DMAEN</name>
@@ -12433,6 +12568,18 @@ xs:noNamespaceSchemaLocation="CMSIS-SVD_Schema_1_1.xsd">
               or SDIO multibyte data transfer.</description>
               <bitOffset>2</bitOffset>
               <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>Block</name>
+                  <description>Block data transfer</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Stream</name>
+                  <description>Stream or SDIO multibyte data transfer</description>
+                  <value>1</value>
+                </enumeratedValue>
+              </enumeratedValues>
             </field>
             <field>
               <name>DTDIR</name>
@@ -12440,6 +12587,18 @@ xs:noNamespaceSchemaLocation="CMSIS-SVD_Schema_1_1.xsd">
               selection</description>
               <bitOffset>1</bitOffset>
               <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>Controller_To_Card</name>
+                  <description>Data is sent to the card</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Card_To_Controller</name>
+                  <description>Data is read from the card</description>
+                  <value>1</value>
+                </enumeratedValue>
+              </enumeratedValues>
             </field>
             <field>
               <name>DTEN</name>


### PR DESCRIPTION
The devices are the same but ST changed the way they are described in
the SVD files, adding enumeration values.

This patch brings the STM32F469 description to the F40x and F429x SVDs.
This will allow shared driver implementation for all the STM32F4
devices.