### PR TITLE
User option for the generation of handler.S and int IDs

### DIFF
--- a/src/ada_gen.adb
+++ b/src/ada_gen.adb
@@ -1011,19 +1011,6 @@ package body Ada_Gen is
       return Spec.Id;
    end Id;
 
-   -----------------------------
-   -- Is_Interfaces_Hierarchy --
-   -----------------------------
-
-   function Is_Interfaces_Hierarchy
-     (Spec : Ada_Spec) return Boolean
-   is
-   begin
-      return Length (Spec.Id) > 10
-        and then Ada.Characters.Handling.To_Lower
-          (Slice (Spec.Id, 1, 11)) = "interfaces.";
-   end Is_Interfaces_Hierarchy;
-
    ---------------------
    -- Add_Global_With --
    ---------------------
@@ -2351,5 +2338,21 @@ package body Ada_Gen is
          Add (Spec, New_With_Clause ("System"));
       end if;
    end Added_In_Spec;
+
+   -----------------
+   -- Starts_With --
+   -----------------
+
+   function Starts_With (S1, S2 : String) return Boolean
+   is (S1'Length >= S2'Length
+       and then S1 (S1'First .. S1'First + S2'Length - 1) = S2);
+
+   ---------------
+   -- Ends_With --
+   ---------------
+
+   function Ends_With (S1, S2 : String) return Boolean
+   is (S1'Length >= S2'Length
+       and then S1 (S1'Last - S2'Length + 1 .. S1'Last) = S2);
 
 end Ada_Gen;

--- a/src/ada_gen.ads
+++ b/src/ada_gen.ads
@@ -336,9 +336,6 @@ package Ada_Gen is
 
    function Id (Spec : Ada_Spec) return Unbounded_String;
 
-   function Is_Interfaces_Hierarchy
-     (Spec : Ada_Spec) return Boolean;
-
    procedure Write_Spec
      (Spec       : Ada_Spec;
       Output_Dir : String);
@@ -389,6 +386,16 @@ package Ada_Gen is
       Id      : String;
       Repr    : Unsigned;
       Comment : String := "") return Ada_Enum_Value;
+
+   -----------------------------
+   -- String comparison utils --
+   -----------------------------
+
+   function Starts_With (S1, S2 : String) return Boolean;
+   --  Whether S1 starts with the substring S2 (or is equal to S2)
+
+   function Ends_With (S1, S2 : String) return Boolean;
+   --  Whether S1 ends with the substring S2 (or is equal to S2)
 
 private
 

--- a/src/svd2ada.adb
+++ b/src/svd2ada.adb
@@ -75,12 +75,13 @@ is
    SVD_File      : Unbounded_String;
 
    --  Command line parser
-   Cmd_Line_Cfg    : GNAT.Command_Line.Command_Line_Configuration;
-   Pkg             : aliased GNAT.Strings.String_Access;
-   Out_Dir         : aliased GNAT.Strings.String_Access;
-   Base_Types_Pkg  : aliased GNAT.Strings.String_Access;
-   Gen_Booleans    : aliased Boolean := False;
-   Gen_UInt_Always : aliased Boolean := False;
+   Cmd_Line_Cfg      : GNAT.Command_Line.Command_Line_Configuration;
+   Pkg               : aliased GNAT.Strings.String_Access;
+   Out_Dir           : aliased GNAT.Strings.String_Access;
+   Base_Types_Pkg    : aliased GNAT.Strings.String_Access;
+   Gen_Booleans      : aliased Boolean := False;
+   Gen_UInt_Always   : aliased Boolean := False;
+   Gen_Trap_Handlers : aliased Boolean := False;
 
    use type GNAT.Strings.String_Access;
 
@@ -127,6 +128,13 @@ begin
       Help        => "when generating base types, always consider UInt* and" &
         " do not use the Bit and Bytes variants for types with size 1 and 8",
       Value       => True);
+   GNAT.Command_Line.Define_Switch
+     (Cmd_Line_Cfg,
+      Output      => Gen_Trap_Handlers'Access,
+      Long_Switch => "--gen-trap-handlers",
+      Help        => "Generate trap handlers (handlers.S) even is the root" &
+        " is not a run-time package",
+      Value       => True);
 
    GNAT.Command_Line.Getopt
      (Config => Cmd_Line_Cfg);
@@ -147,6 +155,7 @@ begin
 
    SVD2Ada_Utils.Set_Use_Boolean_For_Bit (Gen_Booleans);
    SVD2Ada_Utils.Set_Use_UInt (Gen_UInt_Always);
+   SVD2Ada_Utils.Set_Gen_Trap_Handlers (Gen_Trap_Handlers);
 
    if Pkg.all /= "" then
       SVD2Ada_Utils.Set_Root_Package (Pkg.all);

--- a/src/svd2ada_utils.adb
+++ b/src/svd2ada_utils.adb
@@ -25,10 +25,11 @@ with GNAT.OS_Lib;           use GNAT.OS_Lib;
 
 package body SVD2Ada_Utils is
 
-   G_Use_Boolean : Boolean := False;
-   G_Types_Pkg   : Unbounded_String := Null_Unbounded_String;
-   G_Root_Pkg    : Unbounded_String := Null_Unbounded_String;
-   G_Use_UInt    : Boolean := False;
+   G_Use_Boolean       : Boolean := False;
+   G_Types_Pkg         : Unbounded_String := Null_Unbounded_String;
+   G_Root_Pkg          : Unbounded_String := Null_Unbounded_String;
+   G_Use_UInt          : Boolean := False;
+   G_Gen_Trap_Handlers : Boolean := False;
 
    -------------------------
    -- Executable_Location --
@@ -222,5 +223,23 @@ package body SVD2Ada_Utils is
          return True;
       end if;
    end In_Runtime;
+
+   ---------------------------
+   -- Set_Gen_Trap_Handlers --
+   ---------------------------
+
+   procedure Set_Gen_Trap_Handlers (Value : Boolean) is
+   begin
+      G_Gen_Trap_Handlers := Value;
+   end Set_Gen_Trap_Handlers;
+
+   -----------------------
+   -- Gen_Trap_Handlers --
+   -----------------------
+
+   function Gen_Trap_Handlers return Boolean is
+   begin
+      return G_Gen_Trap_Handlers or else In_Runtime;
+   end Gen_Trap_Handlers;
 
 end SVD2Ada_Utils;

--- a/src/svd2ada_utils.ads
+++ b/src/svd2ada_utils.ads
@@ -35,4 +35,13 @@ package SVD2Ada_Utils is
    function Root_Package return String;
    function In_Runtime return Boolean;
 
+   procedure Set_Gen_Trap_Handlers (Value : Boolean);
+   --  Force generation of trap handlers even if the root is not a run-time
+   --  package.
+
+   function Gen_Trap_Handlers return Boolean;
+   --  Returns True if the trap handlers (handler.S) should be generated.
+   --  Trap handlers are generated if the root is a run-time package or if the
+   --  user requested with a command line option.
+
 end SVD2Ada_Utils;


### PR DESCRIPTION
This patch introduces a --gen-trap-handlers to allow generation of trap
handler vector even if the root package is not `Interfaces`.

It also fixes the generation of the `<ROOT>.Interrupts` package when
`<ROOT>` is not `Interrupt`.