### PR TITLE
Add many registers definitions to FE310.svd

### DIFF
--- a/CMSIS-SVD/SiFive/FE310.svd
+++ b/CMSIS-SVD/SiFive/FE310.svd
@@ -3,7 +3,7 @@
   <vendor>SiFive</vendor>
   <vendorID>SiFive</vendorID>
   <name>FE310</name>
-  <series>nrf51</series>
+  <series>Freedom Everywhere</series>
   <version></version>
   <description>E31 CPU Coreplex, high-performance, 32-bit RV32IMAC core
   </description>
@@ -157,6 +157,194 @@
       </registers>
     </peripheral> <!-- GPIO -->
 
+    <peripheral>
+      <name>QSPI0</name>
+      <description>Serial Peripheral Interface.</description>
+      <baseAddress>0x10014000</baseAddress>
+      <groupName>SPI</groupName>
+      <size>32</size>
+      <access>read-write</access>
+
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x1000</size>
+        <usage>registers</usage>
+      </addressBlock>
+
+      <registers>
+
+        <register>
+          <name>SCKDIV</name>
+          <description>Serial Clock Divisor Register.</description>
+          <addressOffset>0x000</addressOffset>
+          <fields>
+            <field><name>SCALE</name><lsb>0</lsb><msb>11</msb></field>
+          </fields>
+        </register>
+
+        <register>
+          <name>SCKMODE</name>
+          <description>Serial Clock Mode Register.</description>
+          <addressOffset>0x004</addressOffset>
+          <fields>
+            <field><name>PHA</name><lsb>0</lsb><msb>0</msb></field>
+	    <field><name>POL</name><lsb>1</lsb><msb>1</msb></field>
+          </fields>
+        </register>
+
+        <register>
+          <name>CSID</name>
+          <description>Chip Select ID Register.</description>
+          <addressOffset>0x010</addressOffset>
+        </register>
+
+        <register>
+          <name>CSDEF</name>
+          <description>Chip Select Default Register.</description>
+          <addressOffset>0x014</addressOffset>
+        </register>
+
+        <register>
+          <name>CSMODE</name>
+          <description>Chip Select Mode Register.</description>
+          <addressOffset>0x018</addressOffset>
+          <fields>
+            <field><name>MODE</name><lsb>0</lsb><msb>1</msb></field>
+          </fields>
+        </register>
+
+        <register>
+          <name>DELAY0</name>
+          <description>Delay Control Register 0.</description>
+          <addressOffset>0x028</addressOffset>
+          <fields>
+            <field><name>CSSCK</name><lsb>0</lsb><msb>7</msb></field>
+	    <field><name>SCKCS</name><lsb>16</lsb><msb>23</msb></field>
+          </fields>
+        </register>
+
+        <register>
+          <name>DELAY1</name>
+          <description>Delay Control Register 1.</description>
+          <addressOffset>0x02C</addressOffset>
+          <fields>
+            <field><name>INTERCS</name><lsb>0</lsb><msb>7</msb></field>
+	    <field><name>INTERXFR</name><lsb>16</lsb><msb>23</msb></field>
+          </fields>
+        </register>
+
+        <register>
+          <name>FMT</name>
+          <description>Frame Format Register.</description>
+          <addressOffset>0x040</addressOffset>
+          <fields>
+            <field><name>PROTO</name><lsb>0</lsb><msb>1</msb></field>
+	    <field><name>ENDIAN</name><lsb>2</lsb><msb>2</msb></field>
+	    <field><name>DIR</name><lsb>3</lsb><msb>3</msb></field>
+	    <field><name>LEN</name><lsb>16</lsb><msb>19</msb></field>
+          </fields>
+        </register>
+
+        <register>
+          <name>TXDATA</name>
+          <description>Transmit Data Register.</description>
+          <addressOffset>0x048</addressOffset>
+          <fields>
+            <field><name>DATA</name><lsb>0</lsb><msb>7</msb></field>
+	    <field><name>FULL</name><lsb>31</lsb><msb>31</msb></field>
+          </fields>
+        </register>
+
+        <register>
+          <name>RXDATA</name>
+          <description>Receive Data Register.</description>
+          <addressOffset>0x04C</addressOffset>
+          <fields>
+            <field><name>DATA</name><lsb>0</lsb><msb>7</msb></field>
+	    <field><name>EMPTY</name><lsb>31</lsb><msb>31</msb></field>
+          </fields>
+        </register>
+
+        <register>
+          <name>TXMARK</name>
+          <description>Transmit Watermark Register.</description>
+          <addressOffset>0x050</addressOffset>
+          <fields>
+            <field><name>TXMARK</name><lsb>0</lsb><msb>2</msb></field>
+          </fields>
+        </register>
+
+        <register>
+          <name>RXMARK</name>
+          <description>Receive Watermark Register.</description>
+          <addressOffset>0x054</addressOffset>
+          <fields>
+            <field><name>RXMARK</name><lsb>0</lsb><msb>2</msb></field>
+          </fields>
+        </register>
+
+        <register>
+          <name>IE</name>
+          <description>SPI Interrupt Enable Register.</description>
+          <addressOffset>0x070</addressOffset>
+          <fields>
+            <field><name>TXWM</name><lsb>0</lsb><msb>0</msb></field>
+            <field><name>RXWM</name><lsb>1</lsb><msb>1</msb></field>
+          </fields>
+        </register>
+
+        <register>
+          <name>IP</name>
+          <description>SPI Interrupt Pending Register.</description>
+          <addressOffset>0x074</addressOffset>
+          <fields>
+            <field><name>TXWM</name><lsb>0</lsb><msb>0</msb></field>
+            <field><name>RXWM</name><lsb>1</lsb><msb>1</msb></field>
+          </fields>
+        </register>
+
+        <register>
+          <name>FCTRL</name>
+          <description>SPI Flash Interface Control Register.</description>
+          <addressOffset>0x060</addressOffset>
+          <fields>
+            <field><name>ENABLE</name><lsb>0</lsb><msb>0</msb></field>
+          </fields>
+        </register>
+
+        <register>
+          <name>FFMT</name>
+          <description>SPI Flash Instruction Format Register.</description>
+          <addressOffset>0x064</addressOffset>
+          <fields>
+            <field><name>CMD_EN</name><lsb>0</lsb><msb>0</msb></field>
+            <field><name>ADDR_LEN</name><lsb>1</lsb><msb>3</msb></field>
+            <field><name>PAD_CNT</name><lsb>4</lsb><msb>7</msb></field>
+            <field><name>CMD_PROTO</name><lsb>8</lsb><msb>9</msb></field>
+            <field><name>ADDR_PROTO</name><lsb>10</lsb><msb>11</msb></field>
+            <field><name>DATA_PROTO</name><lsb>12</lsb><msb>13</msb></field>
+            <field><name>CMD_CODE</name><lsb>16</lsb><msb>23</msb></field>
+            <field><name>PAD_CODE</name><lsb>24</lsb><msb>31</msb></field>
+          </fields>
+        </register>
+
+      </registers>
+
+    </peripheral> <!-- QSPI0 -->
+
+    <peripheral derivedFrom="QSPI0">
+      <name>QSPI1</name>
+      <description>Serial Peripheral Interface.</description>
+      <baseAddress>0x10024000</baseAddress>
+      <groupName>UART</groupName>
+    </peripheral> <!-- QSPI1 -->
+
+    <peripheral derivedFrom="QSPI0">
+      <name>QSPI2</name>
+      <description>Serial Peripheral Interface.</description>
+      <baseAddress>0x10034000</baseAddress>
+      <groupName>UART</groupName>
+    </peripheral> <!-- QSPI1 -->
 
     <peripheral>
       <name>UART0</name>
@@ -297,7 +485,7 @@
 
         <register>
           <name>SCALE_COUNT</name>
-          <description>PWM Scaled Conunter Register.</description>
+          <description>PWM Scaled Counter Register.</description>
           <addressOffset>0x010</addressOffset>
           <fields>
             <field><name>CNT</name><lsb>0</lsb><msb>15</msb></field>
@@ -337,5 +525,524 @@
       <baseAddress>0x10035000</baseAddress>
       <groupName>PWM</groupName>
     </peripheral> <!-- PWM2 -->
+
+    <peripheral>
+      <name>WDT</name>
+      <description>Watchdog Timer.</description>
+      <baseAddress>0x10000000</baseAddress>
+      <groupName>WDT</groupName>
+      <size>32</size>
+      <access>read-write</access>
+
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x1000</size>
+        <usage>registers</usage>
+      </addressBlock>
+
+      <registers>
+
+	<register>
+	  <name>COUNT</name>
+	  <description>Watchdog Count Register.</description>
+	  <addressOffset>0x008</addressOffset>
+	  <fields>
+	    <field><name>CNT</name><lsb>0</lsb><msb>30</msb></field>
+	  </fields>
+	</register>
+
+	<register>
+	  <name>CONFIG</name>
+	  <description>Watchdog Configuration Register.</description>
+	  <addressOffset>0x000</addressOffset>
+	  <fields>
+	    <field><name>SCALE</name><lsb>0</lsb><msb>3</msb></field>
+	    <field><name>SRSTEN</name><lsb>8</lsb><msb>8</msb></field>
+	    <field><name>ZEROCMP</name><lsb>9</lsb><msb>9</msb></field>
+	    <field><name>ENALWAYS</name><lsb>12</lsb><msb>12</msb></field>
+	    <field><name>ENCOREAWAKE</name><lsb>13</lsb><msb>13</msb></field>
+	  </fields>
+	</register>
+
+        <register>
+          <name>SCALE_COUNT</name>
+          <description>Watchdog Scaled Counter Register.</description>
+          <addressOffset>0x010</addressOffset>
+          <fields>
+            <field><name>CNT</name><lsb>0</lsb><msb>15</msb></field>
+          </fields>
+        </register>
+
+        <register>
+          <name>COMPARE</name>
+          <description>Watchdog Compare Register.</description>
+          <addressOffset>0x020</addressOffset>
+          <fields>
+            <field><name>CMP</name><lsb>0</lsb><msb>15</msb></field>
+          </fields>
+        </register>
+
+        <register>
+          <name>KEY</name>
+          <description>Watchdog Key Register.</description>
+          <addressOffset>0x01C</addressOffset>
+        </register>
+
+        <register>
+          <name>FEED</name>
+          <description>Watchdog Feed Address.</description>
+          <addressOffset>0x018</addressOffset>
+        </register>
+
+      </registers>
+    </peripheral> <!-- WDT -->
+
+    <peripheral>
+      <name>RTC</name>
+      <description>Real-Time Clock.</description>
+      <baseAddress>0x10000000</baseAddress>
+      <groupName>RTC</groupName>
+      <size>32</size>
+      <access>read-write</access>
+
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x1000</size>
+        <usage>registers</usage>
+      </addressBlock>
+
+      <registers>
+
+        <register>
+          <name>HI</name>
+          <description>RTC Count Register High.</description>
+          <addressOffset>0x04C</addressOffset>
+          <fields>
+            <field><name>CNT</name><lsb>0</lsb><msb>15</msb></field>
+          </fields>
+        </register>
+
+        <register>
+          <name>LO</name>
+          <description>RTC Count Register Low.</description>
+          <addressOffset>0x048</addressOffset>
+          <fields>
+            <field><name>CNT</name><lsb>0</lsb><msb>31</msb></field>
+          </fields>
+        </register>
+
+        <register>
+          <name>CONFIG</name>
+          <description>RTC Configuration Register.</description>
+          <addressOffset>0x040</addressOffset>
+          <fields>
+            <field><name>SCALE</name><lsb>0</lsb><msb>3</msb></field>
+	    <field><name>ENALWAYS</name><lsb>12</lsb><msb>12</msb></field>
+	    <field><name>CMP_IP</name><lsb>28</lsb><msb>28</msb></field>
+          </fields>
+        </register>
+
+        <register>
+          <name>SCALE_COUNT</name>
+          <description>RTC Scaled Counter Register.</description>
+          <addressOffset>0x050</addressOffset>
+          <fields>
+            <field><name>CNT</name><lsb>0</lsb><msb>15</msb></field>
+          </fields>
+        </register>
+
+        <register>
+          <name>COMPARE</name>
+          <description>RTC Compare Register.</description>
+          <addressOffset>0x060</addressOffset>
+          <fields>
+            <field><name>CMP</name><lsb>0</lsb><msb>31</msb></field>
+          </fields>
+        </register>
+
+      </registers>
+    </peripheral> <!-- RTC -->
+
+    <peripheral>
+      <name>AON</name>
+      <description>AON Clock Configuration.</description>
+      <baseAddress>0x10000000</baseAddress>
+      <groupName>AON</groupName>
+      <size>32</size>
+      <access>read-write</access>
+
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x1000</size>
+        <usage>registers</usage>
+      </addressBlock>
+
+      <registers>
+
+        <register>
+          <name>LFROSCCFG</name>
+          <description>LF Ring Oscillator Configuration Register.</description>
+          <addressOffset>0x070</addressOffset>
+          <fields>
+            <field><name>DIV</name><lsb>0</lsb><msb>5</msb></field>
+	    <field><name>TRIM</name><lsb>16</lsb><msb>20</msb></field>
+            <field><name>ENABLE</name><lsb>30</lsb><msb>30</msb></field>
+	    <field><name>READY</name><lsb>31</lsb><msb>31</msb></field>
+          </fields>
+        </register>
+
+      </registers>
+    </peripheral> <!-- AON -->
+
+    <peripheral>
+      <name>BACKUP</name>
+      <description>Backup Registers.</description>
+      <baseAddress>0x10000080</baseAddress>
+      <groupName>BACKUP</groupName>
+      <size>32</size>
+      <access>read-write</access>
+
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x1000</size>
+        <usage>registers</usage>
+      </addressBlock>
+
+      <registers>
+
+        <register>
+          <name>R0</name>
+          <description>Backup Register 0.</description>
+          <addressOffset>0x000</addressOffset>
+        </register>
+
+        <register>
+          <name>R1</name>
+          <description>Backup Register 1.</description>
+          <addressOffset>0x004</addressOffset>
+        </register>
+
+        <register>
+          <name>R2</name>
+          <description>Backup Register 2.</description>
+          <addressOffset>0x008</addressOffset>
+        </register>
+
+        <register>
+          <name>R3</name>
+          <description>Backup Register 3.</description>
+          <addressOffset>0x00C</addressOffset>
+        </register>
+
+        <register>
+          <name>R4</name>
+          <description>Backup Register 4.</description>
+          <addressOffset>0x010</addressOffset>
+        </register>
+
+        <register>
+          <name>R5</name>
+          <description>Backup Register 5.</description>
+          <addressOffset>0x014</addressOffset>
+        </register>
+
+        <register>
+          <name>R6</name>
+          <description>Backup Register 6.</description>
+          <addressOffset>0x018</addressOffset>
+        </register>
+
+        <register>
+          <name>R7</name>
+          <description>Backup Register 7.</description>
+          <addressOffset>0x01C</addressOffset>
+        </register>
+
+        <register>
+          <name>R8</name>
+          <description>Backup Register 8.</description>
+          <addressOffset>0x020</addressOffset>
+        </register>
+
+        <register>
+          <name>R9</name>
+          <description>Backup Register 9.</description>
+          <addressOffset>0x024</addressOffset>
+        </register>
+
+        <register>
+          <name>R10</name>
+          <description>Backup Register 10.</description>
+          <addressOffset>0x028</addressOffset>
+        </register>
+
+        <register>
+          <name>R11</name>
+          <description>Backup Register 11.</description>
+          <addressOffset>0x02C</addressOffset>
+        </register>
+
+        <register>
+          <name>R12</name>
+          <description>Backup Register 12.</description>
+          <addressOffset>0x030</addressOffset>
+        </register>
+
+        <register>
+          <name>R13</name>
+          <description>Backup Register 13.</description>
+          <addressOffset>0x034</addressOffset>
+        </register>
+
+        <register>
+          <name>R14</name>
+          <description>Backup Register 14.</description>
+          <addressOffset>0x038</addressOffset>
+        </register>
+
+        <register>
+          <name>R15</name>
+          <description>Backup Register 15.</description>
+          <addressOffset>0x03C</addressOffset>
+        </register>
+
+        <register>
+          <name>R16</name>
+          <description>Backup Register 16.</description>
+          <addressOffset>0x040</addressOffset>
+        </register>
+
+        <register>
+          <name>R17</name>
+          <description>Backup Register 17.</description>
+          <addressOffset>0x044</addressOffset>
+        </register>
+
+        <register>
+          <name>R18</name>
+          <description>Backup Register 18.</description>
+          <addressOffset>0x048</addressOffset>
+        </register>
+
+        <register>
+          <name>R19</name>
+          <description>Backup Register 19.</description>
+          <addressOffset>0x04C</addressOffset>
+        </register>
+
+        <register>
+          <name>R20</name>
+          <description>Backup Register 20.</description>
+          <addressOffset>0x050</addressOffset>
+        </register>
+
+        <register>
+          <name>R21</name>
+          <description>Backup Register 21.</description>
+          <addressOffset>0x054</addressOffset>
+        </register>
+
+        <register>
+          <name>R22</name>
+          <description>Backup Register 22.</description>
+          <addressOffset>0x058</addressOffset>
+        </register>
+
+        <register>
+          <name>R23</name>
+          <description>Backup Register 23.</description>
+          <addressOffset>0x05C</addressOffset>
+        </register>
+
+        <register>
+          <name>R24</name>
+          <description>Backup Register 24.</description>
+          <addressOffset>0x060</addressOffset>
+        </register>
+
+        <register>
+          <name>R25</name>
+          <description>Backup Register 25.</description>
+          <addressOffset>0x064</addressOffset>
+        </register>
+
+        <register>
+          <name>R26</name>
+          <description>Backup Register 26.</description>
+          <addressOffset>0x068</addressOffset>
+        </register>
+
+        <register>
+          <name>R27</name>
+          <description>Backup Register 27.</description>
+          <addressOffset>0x06C</addressOffset>
+        </register>
+
+        <register>
+          <name>R28</name>
+          <description>Backup Register 28.</description>
+          <addressOffset>0x070</addressOffset>
+        </register>
+
+        <register>
+          <name>R29</name>
+          <description>Backup Register 29.</description>
+          <addressOffset>0x074</addressOffset>
+        </register>
+
+        <register>
+          <name>R30</name>
+          <description>Backup Register 30.</description>
+          <addressOffset>0x078</addressOffset>
+        </register>
+
+        <register>
+          <name>R31</name>
+          <description>Backup Register 31.</description>
+          <addressOffset>0x07C</addressOffset>
+        </register>
+
+      </registers>
+    </peripheral> <!-- BACKUP -->
+
+    <peripheral>
+      <name>PMU</name>
+      <description>Power Management Unit.</description>
+      <baseAddress>0x10000000</baseAddress>
+      <groupName>PMU</groupName>
+      <size>32</size>
+      <access>read-write</access>
+
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x1000</size>
+        <usage>registers</usage>
+      </addressBlock>
+
+      <registers>
+
+        <register>
+          <name>WAKEUPI0</name>
+          <description>Wakeup program instruction 0.</description>
+          <addressOffset>0x100</addressOffset>
+        </register>
+
+        <register>
+          <name>WAKEUPI1</name>
+          <description>Wakeup program instruction 1.</description>
+          <addressOffset>0x104</addressOffset>
+        </register>
+
+        <register>
+          <name>WAKEUPI2</name>
+          <description>Wakeup program instruction 2.</description>
+          <addressOffset>0x108</addressOffset>
+        </register>
+
+        <register>
+          <name>WAKEUPI3</name>
+          <description>Wakeup program instruction 3.</description>
+          <addressOffset>0x10C</addressOffset>
+        </register>
+
+        <register>
+          <name>WAKEUPI4</name>
+          <description>Wakeup program instruction 4.</description>
+          <addressOffset>0x110</addressOffset>
+        </register>
+
+        <register>
+          <name>WAKEUPI5</name>
+          <description>Wakeup program instruction 5.</description>
+          <addressOffset>0x114</addressOffset>
+        </register>
+
+        <register>
+          <name>WAKEUPI6</name>
+          <description>Wakeup program instruction 6.</description>
+          <addressOffset>0x118</addressOffset>
+        </register>
+
+        <register>
+          <name>WAKEUPI7</name>
+          <description>Wakeup program instruction 7.</description>
+          <addressOffset>0x11C</addressOffset>
+        </register>
+
+        <register>
+          <name>SLEEPI0</name>
+          <description>Sleep program instruction 0.</description>
+          <addressOffset>0x120</addressOffset>
+        </register>
+
+        <register>
+          <name>SLEEPI1</name>
+          <description>Sleep program instruction 1.</description>
+          <addressOffset>0x124</addressOffset>
+        </register>
+
+        <register>
+          <name>SLEEPI2</name>
+          <description>Sleep program instruction 2.</description>
+          <addressOffset>0x128</addressOffset>
+        </register>
+
+        <register>
+          <name>SLEEPI3</name>
+          <description>Sleep program instruction 3.</description>
+          <addressOffset>0x12C</addressOffset>
+        </register>
+
+        <register>
+          <name>SLEEPI4</name>
+          <description>Sleep program instruction 4.</description>
+          <addressOffset>0x130</addressOffset>
+        </register>
+
+        <register>
+          <name>SLEEPI5</name>
+          <description>Sleep program instruction 5.</description>
+          <addressOffset>0x134</addressOffset>
+        </register>
+
+        <register>
+          <name>SLEEPI6</name>
+          <description>Sleep program instruction 6.</description>
+          <addressOffset>0x138</addressOffset>
+        </register>
+
+        <register>
+          <name>SLEEPI7</name>
+          <description>Sleep program instruction 7.</description>
+          <addressOffset>0x13C</addressOffset>
+        </register>
+
+        <register>
+          <name>IE</name>
+          <description>PMU interrupt enables.</description>
+          <addressOffset>0x140</addressOffset>
+        </register>
+
+        <register>
+          <name>CAUSE</name>
+          <description>PMU wakeup cause.</description>
+          <addressOffset>0x144</addressOffset>
+        </register>
+
+        <register>
+          <name>SLEEP</name>
+          <description>Initiate sleep sequence.</description>
+          <addressOffset>0x148</addressOffset>
+        </register>
+
+        <register>
+          <name>KEY</name>
+          <description>PMU key register.</description>
+          <addressOffset>0x14C</addressOffset>
+        </register>
+
+      </registers>
+    </peripheral> <!-- PMU -->
+
   </peripherals>
 </device>

--- a/CMSIS-SVD/SiFive/FE310.svd
+++ b/CMSIS-SVD/SiFive/FE310.svd
@@ -842,10 +842,11 @@
           <addressOffset>0x00</addressOffset>
           <fields>
             <field><name>SCALE</name><lsb>0</lsb><msb>3</msb></field>
-            <field><name>SRSTEN</name><lsb>8</lsb><msb>8</msb></field>
+            <field><name>RSTEN</name><lsb>8</lsb><msb>8</msb></field>
             <field><name>ZEROCMP</name><lsb>9</lsb><msb>9</msb></field>
             <field><name>ENALWAYS</name><lsb>12</lsb><msb>12</msb></field>
             <field><name>ENCOREAWAKE</name><lsb>13</lsb><msb>13</msb></field>
+            <field><name>CMP_IP</name><lsb>28</lsb><msb>28</msb></field>
           </fields>
         </register>
 
@@ -1078,12 +1079,12 @@
                 <enumeratedValue>
                   <name>External</name>
                   <description>External reset.</description>
-                  <value>0</value>
+                  <value>1</value>
                 </enumeratedValue>
                 <enumeratedValue>
                   <name>Watchdog</name>
                   <description>Watchdog timer reset.</description>
-                  <value>1</value>
+                  <value>2</value>
                 </enumeratedValue>
               </enumeratedValues>
             </field>

--- a/CMSIS-SVD/SiFive/FE310.svd
+++ b/CMSIS-SVD/SiFive/FE310.svd
@@ -20,6 +20,56 @@
   </cpu>
 
   <peripherals>
+
+    <peripheral>
+      <name>CLINT</name>
+      <description>Core Local Interruptor.</description>
+      <baseAddress>0x02000000</baseAddress>
+      <groupName>CLINT</groupName>
+      <size>32</size>
+      <access>read-write</access>
+
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10000</size>
+        <usage>registers</usage>
+      </addressBlock>
+
+      <registers>
+
+        <register>
+          <name>MSIP</name>
+          <description>Machine Software Interrupt Pending Register.</description>
+          <addressOffset>0x0000</addressOffset>
+        </register>
+
+        <register>
+          <name>MTIMECMP_LO</name>
+          <description>Machine Timer Compare Register Low.</description>
+          <addressOffset>0x4000</addressOffset>
+        </register>
+
+        <register>
+          <name>MTIMECMP_HI</name>
+          <description>Machine Timer Compare Register High.</description>
+          <addressOffset>0x4004</addressOffset>
+        </register>
+
+        <register>
+          <name>MTIME_LO</name>
+          <description>Machine Timer Register Low.</description>
+          <addressOffset>0xBFF8</addressOffset>
+        </register>
+
+        <register>
+          <name>MTIME_HI</name>
+          <description>Machine Timer Register High.</description>
+          <addressOffset>0xBFFC</addressOffset>
+        </register>
+
+      </registers>
+    </peripheral> <!-- CLINT -->
+
     <peripheral>
       <name>GPIO0</name>
       <description>General purpose input/output controller.</description>
@@ -536,7 +586,7 @@
 
       <addressBlock>
         <offset>0</offset>
-        <size>0x1000</size>
+        <size>0x40</size>
         <usage>registers</usage>
       </addressBlock>
 
@@ -545,7 +595,7 @@
 	<register>
 	  <name>COUNT</name>
 	  <description>Watchdog Count Register.</description>
-	  <addressOffset>0x008</addressOffset>
+	  <addressOffset>0x08</addressOffset>
 	  <fields>
 	    <field><name>CNT</name><lsb>0</lsb><msb>30</msb></field>
 	  </fields>
@@ -554,7 +604,7 @@
 	<register>
 	  <name>CONFIG</name>
 	  <description>Watchdog Configuration Register.</description>
-	  <addressOffset>0x000</addressOffset>
+	  <addressOffset>0x00</addressOffset>
 	  <fields>
 	    <field><name>SCALE</name><lsb>0</lsb><msb>3</msb></field>
 	    <field><name>SRSTEN</name><lsb>8</lsb><msb>8</msb></field>
@@ -567,7 +617,7 @@
         <register>
           <name>SCALE_COUNT</name>
           <description>Watchdog Scaled Counter Register.</description>
-          <addressOffset>0x010</addressOffset>
+          <addressOffset>0x10</addressOffset>
           <fields>
             <field><name>CNT</name><lsb>0</lsb><msb>15</msb></field>
           </fields>
@@ -576,7 +626,7 @@
         <register>
           <name>COMPARE</name>
           <description>Watchdog Compare Register.</description>
-          <addressOffset>0x020</addressOffset>
+          <addressOffset>0x20</addressOffset>
           <fields>
             <field><name>CMP</name><lsb>0</lsb><msb>15</msb></field>
           </fields>
@@ -585,13 +635,13 @@
         <register>
           <name>KEY</name>
           <description>Watchdog Key Register.</description>
-          <addressOffset>0x01C</addressOffset>
+          <addressOffset>0x1C</addressOffset>
         </register>
 
         <register>
           <name>FEED</name>
           <description>Watchdog Feed Address.</description>
-          <addressOffset>0x018</addressOffset>
+          <addressOffset>0x18</addressOffset>
         </register>
 
       </registers>
@@ -600,14 +650,14 @@
     <peripheral>
       <name>RTC</name>
       <description>Real-Time Clock.</description>
-      <baseAddress>0x10000000</baseAddress>
+      <baseAddress>0x10000040</baseAddress>
       <groupName>RTC</groupName>
       <size>32</size>
       <access>read-write</access>
 
       <addressBlock>
         <offset>0</offset>
-        <size>0x1000</size>
+        <size>0x30</size>
         <usage>registers</usage>
       </addressBlock>
 
@@ -616,7 +666,7 @@
         <register>
           <name>HI</name>
           <description>RTC Count Register High.</description>
-          <addressOffset>0x04C</addressOffset>
+          <addressOffset>0x0C</addressOffset>
           <fields>
             <field><name>CNT</name><lsb>0</lsb><msb>15</msb></field>
           </fields>
@@ -625,13 +675,13 @@
         <register>
           <name>LO</name>
           <description>RTC Count Register Low.</description>
-          <addressOffset>0x048</addressOffset>
+          <addressOffset>0x08</addressOffset>
         </register>
 
         <register>
           <name>CONFIG</name>
           <description>RTC Configuration Register.</description>
-          <addressOffset>0x040</addressOffset>
+          <addressOffset>0x00</addressOffset>
           <fields>
             <field><name>SCALE</name><lsb>0</lsb><msb>3</msb></field>
 	    <field><name>ENALWAYS</name><lsb>12</lsb><msb>12</msb></field>
@@ -642,13 +692,13 @@
         <register>
           <name>SCALE_COUNT</name>
           <description>RTC Scaled Counter Register.</description>
-          <addressOffset>0x050</addressOffset>
+          <addressOffset>0x10</addressOffset>
         </register>
 
         <register>
           <name>COMPARE</name>
           <description>RTC Compare Register.</description>
-          <addressOffset>0x060</addressOffset>
+          <addressOffset>0x20</addressOffset>
         </register>
 
       </registers>
@@ -657,14 +707,14 @@
     <peripheral>
       <name>AON</name>
       <description>AON Clock Configuration.</description>
-      <baseAddress>0x10000000</baseAddress>
+      <baseAddress>0x10000070</baseAddress>
       <groupName>AON</groupName>
       <size>32</size>
       <access>read-write</access>
 
       <addressBlock>
         <offset>0</offset>
-        <size>0x1000</size>
+        <size>0x10</size>
         <usage>registers</usage>
       </addressBlock>
 
@@ -673,7 +723,7 @@
         <register>
           <name>LFROSCCFG</name>
           <description>LF Ring Oscillator Configuration Register.</description>
-          <addressOffset>0x070</addressOffset>
+          <addressOffset>0x0</addressOffset>
           <fields>
             <field><name>DIV</name><lsb>0</lsb><msb>5</msb></field>
 	    <field><name>TRIM</name><lsb>16</lsb><msb>20</msb></field>
@@ -695,7 +745,7 @@
 
       <addressBlock>
         <offset>0</offset>
-        <size>0x1000</size>
+        <size>0x80</size>
         <usage>registers</usage>
       </addressBlock>
 
@@ -704,193 +754,193 @@
         <register>
           <name>R0</name>
           <description>Backup Register 0.</description>
-          <addressOffset>0x000</addressOffset>
+          <addressOffset>0x00</addressOffset>
         </register>
 
         <register>
           <name>R1</name>
           <description>Backup Register 1.</description>
-          <addressOffset>0x004</addressOffset>
+          <addressOffset>0x04</addressOffset>
         </register>
 
         <register>
           <name>R2</name>
           <description>Backup Register 2.</description>
-          <addressOffset>0x008</addressOffset>
+          <addressOffset>0x08</addressOffset>
         </register>
 
         <register>
           <name>R3</name>
           <description>Backup Register 3.</description>
-          <addressOffset>0x00C</addressOffset>
+          <addressOffset>0x0C</addressOffset>
         </register>
 
         <register>
           <name>R4</name>
           <description>Backup Register 4.</description>
-          <addressOffset>0x010</addressOffset>
+          <addressOffset>0x10</addressOffset>
         </register>
 
         <register>
           <name>R5</name>
           <description>Backup Register 5.</description>
-          <addressOffset>0x014</addressOffset>
+          <addressOffset>0x14</addressOffset>
         </register>
 
         <register>
           <name>R6</name>
           <description>Backup Register 6.</description>
-          <addressOffset>0x018</addressOffset>
+          <addressOffset>0x18</addressOffset>
         </register>
 
         <register>
           <name>R7</name>
           <description>Backup Register 7.</description>
-          <addressOffset>0x01C</addressOffset>
+          <addressOffset>0x1C</addressOffset>
         </register>
 
         <register>
           <name>R8</name>
           <description>Backup Register 8.</description>
-          <addressOffset>0x020</addressOffset>
+          <addressOffset>0x20</addressOffset>
         </register>
 
         <register>
           <name>R9</name>
           <description>Backup Register 9.</description>
-          <addressOffset>0x024</addressOffset>
+          <addressOffset>0x24</addressOffset>
         </register>
 
         <register>
           <name>R10</name>
           <description>Backup Register 10.</description>
-          <addressOffset>0x028</addressOffset>
+          <addressOffset>0x28</addressOffset>
         </register>
 
         <register>
           <name>R11</name>
           <description>Backup Register 11.</description>
-          <addressOffset>0x02C</addressOffset>
+          <addressOffset>0x2C</addressOffset>
         </register>
 
         <register>
           <name>R12</name>
           <description>Backup Register 12.</description>
-          <addressOffset>0x030</addressOffset>
+          <addressOffset>0x30</addressOffset>
         </register>
 
         <register>
           <name>R13</name>
           <description>Backup Register 13.</description>
-          <addressOffset>0x034</addressOffset>
+          <addressOffset>0x34</addressOffset>
         </register>
 
         <register>
           <name>R14</name>
           <description>Backup Register 14.</description>
-          <addressOffset>0x038</addressOffset>
+          <addressOffset>0x38</addressOffset>
         </register>
 
         <register>
           <name>R15</name>
           <description>Backup Register 15.</description>
-          <addressOffset>0x03C</addressOffset>
+          <addressOffset>0x3C</addressOffset>
         </register>
 
         <register>
           <name>R16</name>
           <description>Backup Register 16.</description>
-          <addressOffset>0x040</addressOffset>
+          <addressOffset>0x40</addressOffset>
         </register>
 
         <register>
           <name>R17</name>
           <description>Backup Register 17.</description>
-          <addressOffset>0x044</addressOffset>
+          <addressOffset>0x44</addressOffset>
         </register>
 
         <register>
           <name>R18</name>
           <description>Backup Register 18.</description>
-          <addressOffset>0x048</addressOffset>
+          <addressOffset>0x48</addressOffset>
         </register>
 
         <register>
           <name>R19</name>
           <description>Backup Register 19.</description>
-          <addressOffset>0x04C</addressOffset>
+          <addressOffset>0x4C</addressOffset>
         </register>
 
         <register>
           <name>R20</name>
           <description>Backup Register 20.</description>
-          <addressOffset>0x050</addressOffset>
+          <addressOffset>0x50</addressOffset>
         </register>
 
         <register>
           <name>R21</name>
           <description>Backup Register 21.</description>
-          <addressOffset>0x054</addressOffset>
+          <addressOffset>0x54</addressOffset>
         </register>
 
         <register>
           <name>R22</name>
           <description>Backup Register 22.</description>
-          <addressOffset>0x058</addressOffset>
+          <addressOffset>0x58</addressOffset>
         </register>
 
         <register>
           <name>R23</name>
           <description>Backup Register 23.</description>
-          <addressOffset>0x05C</addressOffset>
+          <addressOffset>0x5C</addressOffset>
         </register>
 
         <register>
           <name>R24</name>
           <description>Backup Register 24.</description>
-          <addressOffset>0x060</addressOffset>
+          <addressOffset>0x60</addressOffset>
         </register>
 
         <register>
           <name>R25</name>
           <description>Backup Register 25.</description>
-          <addressOffset>0x064</addressOffset>
+          <addressOffset>0x64</addressOffset>
         </register>
 
         <register>
           <name>R26</name>
           <description>Backup Register 26.</description>
-          <addressOffset>0x068</addressOffset>
+          <addressOffset>0x68</addressOffset>
         </register>
 
         <register>
           <name>R27</name>
           <description>Backup Register 27.</description>
-          <addressOffset>0x06C</addressOffset>
+          <addressOffset>0x6C</addressOffset>
         </register>
 
         <register>
           <name>R28</name>
           <description>Backup Register 28.</description>
-          <addressOffset>0x070</addressOffset>
+          <addressOffset>0x70</addressOffset>
         </register>
 
         <register>
           <name>R29</name>
           <description>Backup Register 29.</description>
-          <addressOffset>0x074</addressOffset>
+          <addressOffset>0x74</addressOffset>
         </register>
 
         <register>
           <name>R30</name>
           <description>Backup Register 30.</description>
-          <addressOffset>0x078</addressOffset>
+          <addressOffset>0x78</addressOffset>
         </register>
 
         <register>
           <name>R31</name>
           <description>Backup Register 31.</description>
-          <addressOffset>0x07C</addressOffset>
+          <addressOffset>0x7C</addressOffset>
         </register>
 
       </registers>
@@ -899,14 +949,14 @@
     <peripheral>
       <name>PMU</name>
       <description>Power Management Unit.</description>
-      <baseAddress>0x10000000</baseAddress>
+      <baseAddress>0x10000100</baseAddress>
       <groupName>PMU</groupName>
       <size>32</size>
       <access>read-write</access>
 
       <addressBlock>
         <offset>0</offset>
-        <size>0x1000</size>
+        <size>0x50</size>
         <usage>registers</usage>
       </addressBlock>
 
@@ -915,121 +965,121 @@
         <register>
           <name>WAKEUPI0</name>
           <description>Wakeup program instruction 0.</description>
-          <addressOffset>0x100</addressOffset>
+          <addressOffset>0x00</addressOffset>
         </register>
 
         <register>
           <name>WAKEUPI1</name>
           <description>Wakeup program instruction 1.</description>
-          <addressOffset>0x104</addressOffset>
+          <addressOffset>0x04</addressOffset>
         </register>
 
         <register>
           <name>WAKEUPI2</name>
           <description>Wakeup program instruction 2.</description>
-          <addressOffset>0x108</addressOffset>
+          <addressOffset>0x08</addressOffset>
         </register>
 
         <register>
           <name>WAKEUPI3</name>
           <description>Wakeup program instruction 3.</description>
-          <addressOffset>0x10C</addressOffset>
+          <addressOffset>0x0C</addressOffset>
         </register>
 
         <register>
           <name>WAKEUPI4</name>
           <description>Wakeup program instruction 4.</description>
-          <addressOffset>0x110</addressOffset>
+          <addressOffset>0x10</addressOffset>
         </register>
 
         <register>
           <name>WAKEUPI5</name>
           <description>Wakeup program instruction 5.</description>
-          <addressOffset>0x114</addressOffset>
+          <addressOffset>0x14</addressOffset>
         </register>
 
         <register>
           <name>WAKEUPI6</name>
           <description>Wakeup program instruction 6.</description>
-          <addressOffset>0x118</addressOffset>
+          <addressOffset>0x18</addressOffset>
         </register>
 
         <register>
           <name>WAKEUPI7</name>
           <description>Wakeup program instruction 7.</description>
-          <addressOffset>0x11C</addressOffset>
+          <addressOffset>0x1C</addressOffset>
         </register>
 
         <register>
           <name>SLEEPI0</name>
           <description>Sleep program instruction 0.</description>
-          <addressOffset>0x120</addressOffset>
+          <addressOffset>0x20</addressOffset>
         </register>
 
         <register>
           <name>SLEEPI1</name>
           <description>Sleep program instruction 1.</description>
-          <addressOffset>0x124</addressOffset>
+          <addressOffset>0x24</addressOffset>
         </register>
 
         <register>
           <name>SLEEPI2</name>
           <description>Sleep program instruction 2.</description>
-          <addressOffset>0x128</addressOffset>
+          <addressOffset>0x28</addressOffset>
         </register>
 
         <register>
           <name>SLEEPI3</name>
           <description>Sleep program instruction 3.</description>
-          <addressOffset>0x12C</addressOffset>
+          <addressOffset>0x2C</addressOffset>
         </register>
 
         <register>
           <name>SLEEPI4</name>
           <description>Sleep program instruction 4.</description>
-          <addressOffset>0x130</addressOffset>
+          <addressOffset>0x30</addressOffset>
         </register>
 
         <register>
           <name>SLEEPI5</name>
           <description>Sleep program instruction 5.</description>
-          <addressOffset>0x134</addressOffset>
+          <addressOffset>0x34</addressOffset>
         </register>
 
         <register>
           <name>SLEEPI6</name>
           <description>Sleep program instruction 6.</description>
-          <addressOffset>0x138</addressOffset>
+          <addressOffset>0x38</addressOffset>
         </register>
 
         <register>
           <name>SLEEPI7</name>
           <description>Sleep program instruction 7.</description>
-          <addressOffset>0x13C</addressOffset>
+          <addressOffset>0x3C</addressOffset>
         </register>
 
         <register>
           <name>IE</name>
           <description>PMU interrupt enables.</description>
-          <addressOffset>0x140</addressOffset>
+          <addressOffset>0x40</addressOffset>
         </register>
 
         <register>
           <name>CAUSE</name>
           <description>PMU wakeup cause.</description>
-          <addressOffset>0x144</addressOffset>
+          <addressOffset>0x44</addressOffset>
         </register>
 
         <register>
           <name>SLEEP</name>
           <description>Initiate sleep sequence.</description>
-          <addressOffset>0x148</addressOffset>
+          <addressOffset>0x48</addressOffset>
         </register>
 
         <register>
           <name>KEY</name>
           <description>PMU key register.</description>
-          <addressOffset>0x14C</addressOffset>
+          <addressOffset>0x4C</addressOffset>
         </register>
 
       </registers>

--- a/CMSIS-SVD/SiFive/FE310.svd
+++ b/CMSIS-SVD/SiFive/FE310.svd
@@ -237,8 +237,44 @@
           <description>Serial Clock Mode Register.</description>
           <addressOffset>0x004</addressOffset>
           <fields>
-            <field><name>PHA</name><lsb>0</lsb><msb>0</msb></field>
-	    <field><name>POL</name><lsb>1</lsb><msb>1</msb></field>
+            <field>
+              <name>PHA</name><lsb>0</lsb><msb>0</msb>
+              <description>Serial Clock Phase</description>
+              <enumeratedValues>
+                <name>CPHA</name>                
+                <enumeratedValue>
+                  <name>0</name>
+                  <description>
+                  Data is sampled on the leading edge of SCK and shifted on the trailing edge of SCK.
+                  </description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1</name>
+                  <description>
+                  Data is shifted on the leading edge of SCK and sampled on the trailing edge of SCK.
+                  </description>
+                  <value>1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>POL</name><lsb>1</lsb><msb>1</msb>
+              <description>Serial Clock Polarity</description>
+              <enumeratedValues>
+                <name>CPOL</name>                
+                <enumeratedValue>
+                  <name>0</name>
+                  <description>Inactive state of SCK is logical 0.</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1</name>
+                  <description>Inactive state of SCK is logical 1.</description>
+                  <value>1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
           </fields>
         </register>
 
@@ -259,7 +295,27 @@
           <description>Chip Select Mode Register.</description>
           <addressOffset>0x018</addressOffset>
           <fields>
-            <field><name>MODE</name><lsb>0</lsb><msb>1</msb></field>
+            <field>
+              <name>MODE</name><lsb>0</lsb><msb>1</msb>
+              <enumeratedValues>
+                <name>Chip_Select_Modes</name>
+                <enumeratedValue>
+                  <name>AUTO</name>
+                  <description>Assert/de-assert CS at the beginning/end of each frame.</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HOLD</name>
+                  <description>Keep CS continuously asserted after the initial frame.</description>
+                  <value>2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>Disable hardware control of the CS pin.</description>
+                  <value>3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
           </fields>
         </register>
 
@@ -269,7 +325,7 @@
           <addressOffset>0x028</addressOffset>
           <fields>
             <field><name>CSSCK</name><lsb>0</lsb><msb>7</msb></field>
-	    <field><name>SCKCS</name><lsb>16</lsb><msb>23</msb></field>
+            <field><name>SCKCS</name><lsb>16</lsb><msb>23</msb></field>
           </fields>
         </register>
 
@@ -279,7 +335,7 @@
           <addressOffset>0x02C</addressOffset>
           <fields>
             <field><name>INTERCS</name><lsb>0</lsb><msb>7</msb></field>
-	    <field><name>INTERXFR</name><lsb>16</lsb><msb>23</msb></field>
+            <field><name>INTERXFR</name><lsb>16</lsb><msb>23</msb></field>
           </fields>
         </register>
 
@@ -288,10 +344,65 @@
           <description>Frame Format Register.</description>
           <addressOffset>0x040</addressOffset>
           <fields>
-            <field><name>PROTO</name><lsb>0</lsb><msb>1</msb></field>
-	    <field><name>ENDIAN</name><lsb>2</lsb><msb>2</msb></field>
-	    <field><name>DIR</name><lsb>3</lsb><msb>3</msb></field>
-	    <field><name>LEN</name><lsb>16</lsb><msb>19</msb></field>
+            <field>
+              <name>PROTO</name><lsb>0</lsb><msb>1</msb>
+              <enumeratedValues>
+                <name>SPI_Protocol</name>
+                <enumeratedValue>
+                  <name>Single</name>
+                  <description>Data Pins: DQ0 (MOSI), DQ1 (MISO).</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Dual</name>
+                  <description>Data Pins: DQ0, DQ1.</description>
+                  <value>1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Quad</name>
+                  <description>Data Pins: DQ0, DQ1, DQ2, DQ3.</description>
+                  <value>2</value>
+                </enumeratedValue>
+              </enumeratedValues>              
+            </field>
+            <field>
+              <name>ENDIAN</name><lsb>2</lsb><msb>2</msb>
+              <enumeratedValues>
+                <name>SPI_Endianness</name>
+                <enumeratedValue>
+                  <name>MSB_First</name>
+                  <description>Tansmit most-significant bit first.</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LSB_First</name>
+                  <description>Transmit least-significant bit first.</description>
+                  <value>1</value>
+                </enumeratedValue>
+              </enumeratedValues> 
+            </field>
+            <field>
+              <name>DIR</name><lsb>3</lsb><msb>3</msb>
+              <enumeratedValues>
+                <name>SPI_IO_Direction</name>
+                <enumeratedValue>
+                  <name>RX</name>
+                  <description>
+                  For dual and quad protocols, the DQ pins are tri-stated. 
+                  For the single protocol, the DQ0 pin is driven with the transmit data as normal.
+                  </description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TX</name>
+                  <description>The receive FIFO is not populated.</description>
+                  <value>1</value>
+                </enumeratedValue>
+              </enumeratedValues> 
+            </field>
+            <field>
+              <name>LEN</name><lsb>16</lsb><msb>19</msb>
+            </field>
           </fields>
         </register>
 
@@ -301,7 +412,7 @@
           <addressOffset>0x048</addressOffset>
           <fields>
             <field><name>DATA</name><lsb>0</lsb><msb>7</msb></field>
-	    <field><name>FULL</name><lsb>31</lsb><msb>31</msb></field>
+            <field><name>FULL</name><lsb>31</lsb><msb>31</msb></field>
           </fields>
         </register>
 
@@ -311,7 +422,7 @@
           <addressOffset>0x04C</addressOffset>
           <fields>
             <field><name>DATA</name><lsb>0</lsb><msb>7</msb></field>
-	    <field><name>EMPTY</name><lsb>31</lsb><msb>31</msb></field>
+            <field><name>EMPTY</name><lsb>31</lsb><msb>31</msb></field>
           </fields>
         </register>
 
@@ -592,27 +703,27 @@
 
       <registers>
 
-	<register>
-	  <name>COUNT</name>
-	  <description>Watchdog Count Register.</description>
-	  <addressOffset>0x08</addressOffset>
-	  <fields>
-	    <field><name>CNT</name><lsb>0</lsb><msb>30</msb></field>
-	  </fields>
-	</register>
+        <register>
+          <name>COUNT</name>
+          <description>Watchdog Count Register.</description>
+          <addressOffset>0x08</addressOffset>
+          <fields>
+            <field><name>CNT</name><lsb>0</lsb><msb>30</msb></field>
+          </fields>
+        </register>
 
-	<register>
-	  <name>CONFIG</name>
-	  <description>Watchdog Configuration Register.</description>
-	  <addressOffset>0x00</addressOffset>
-	  <fields>
-	    <field><name>SCALE</name><lsb>0</lsb><msb>3</msb></field>
-	    <field><name>SRSTEN</name><lsb>8</lsb><msb>8</msb></field>
-	    <field><name>ZEROCMP</name><lsb>9</lsb><msb>9</msb></field>
-	    <field><name>ENALWAYS</name><lsb>12</lsb><msb>12</msb></field>
-	    <field><name>ENCOREAWAKE</name><lsb>13</lsb><msb>13</msb></field>
-	  </fields>
-	</register>
+        <register>
+          <name>CONFIG</name>
+          <description>Watchdog Configuration Register.</description>
+          <addressOffset>0x00</addressOffset>
+          <fields>
+            <field><name>SCALE</name><lsb>0</lsb><msb>3</msb></field>
+            <field><name>SRSTEN</name><lsb>8</lsb><msb>8</msb></field>
+            <field><name>ZEROCMP</name><lsb>9</lsb><msb>9</msb></field>
+            <field><name>ENALWAYS</name><lsb>12</lsb><msb>12</msb></field>
+            <field><name>ENCOREAWAKE</name><lsb>13</lsb><msb>13</msb></field>
+          </fields>
+        </register>
 
         <register>
           <name>SCALE_COUNT</name>
@@ -684,8 +795,8 @@
           <addressOffset>0x00</addressOffset>
           <fields>
             <field><name>SCALE</name><lsb>0</lsb><msb>3</msb></field>
-	    <field><name>ENALWAYS</name><lsb>12</lsb><msb>12</msb></field>
-	    <field><name>CMP_IP</name><lsb>28</lsb><msb>28</msb></field>
+            <field><name>ENALWAYS</name><lsb>12</lsb><msb>12</msb></field>
+            <field><name>CMP_IP</name><lsb>28</lsb><msb>28</msb></field>
           </fields>
         </register>
 
@@ -726,9 +837,9 @@
           <addressOffset>0x0</addressOffset>
           <fields>
             <field><name>DIV</name><lsb>0</lsb><msb>5</msb></field>
-	    <field><name>TRIM</name><lsb>16</lsb><msb>20</msb></field>
+            <field><name>TRIM</name><lsb>16</lsb><msb>20</msb></field>
             <field><name>ENABLE</name><lsb>30</lsb><msb>30</msb></field>
-	    <field><name>READY</name><lsb>31</lsb><msb>31</msb></field>
+            <field><name>READY</name><lsb>31</lsb><msb>31</msb></field>
           </fields>
         </register>
 
@@ -752,8 +863,8 @@
       <registers>
 
         <register>
-	  	  <dim>32</dim>
-	  	  <dimIncrement>4</dimIncrement>
+          <dim>32</dim>
+          <dimIncrement>4</dimIncrement>
           <name>Backup[%s]</name>
           <addressOffset>0x00</addressOffset>
         </register>
@@ -778,16 +889,21 @@
       <registers>
 
         <register>
-	  	  <dim>8</dim>
-	  	  <dimIncrement>4</dimIncrement>
+          <dim>8</dim>
+          <dimIncrement>4</dimIncrement>
           <name>WAKEUPI[%s]</name>
           <description>Wakeup program instructions.</description>
           <addressOffset>0x00</addressOffset>
+          <fields>
+            <field><name>DELAY</name><lsb>0</lsb><msb>3</msb></field>
+            <field><name>PMU_OUT_0</name><lsb>4</lsb><msb>4</msb></field>
+            <field><name>PMU_OUT_1</name><lsb>5</lsb><msb>5</msb></field>
+            <field><name>CORERST</name><lsb>7</lsb><msb>7</msb></field>
+            <field><name>HFCLKRST</name><lsb>8</lsb><msb>8</msb></field>
+          </fields>
         </register>
 
-        <register>
-	  	  <dim>8</dim>
-	  	  <dimIncrement>4</dimIncrement>
+        <register derivedFrom="WAKEUPI[%s]">
           <name>SLEEPI[%s]</name>
           <description>Sleep program instructions.</description>
           <addressOffset>0x20</addressOffset>
@@ -797,12 +913,55 @@
           <name>IE</name>
           <description>PMU interrupt enables.</description>
           <addressOffset>0x40</addressOffset>
+          <fields>
+            <field><name>RTC</name><lsb>1</lsb><msb>1</msb></field>
+            <field><name>DWAKEUP</name><lsb>2</lsb><msb>2</msb></field>
+          </fields>
         </register>
 
         <register>
           <name>CAUSE</name>
           <description>PMU wakeup cause.</description>
           <addressOffset>0x44</addressOffset>
+          <fields>
+            <field>
+              <name>WAKEUP_CAUSE</name><lsb>0</lsb><msb>1</msb>
+              <enumeratedValues>
+                <name>Wakeup_Cause_Values</name>
+                <enumeratedValue>
+                  <name>Reset</name>
+                  <description>Reset.</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RTC</name>
+                  <description>RTC Wakeup.</description>
+                  <value>1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DWakeup</name>
+                  <description>Digital input wakeup.</description>
+                  <value>2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RESET_CAUSE</name><lsb>8</lsb><msb>9</msb>
+              <enumeratedValues>
+                <name>Reset_Cause_Values</name>
+                <enumeratedValue>
+                  <name>External</name>
+                  <description>External reset.</description>
+                  <value>0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Watchdog</name>
+                  <description>Watchdog timer reset.</description>
+                  <value>1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
         </register>
 
         <register>

--- a/CMSIS-SVD/SiFive/FE310.svd
+++ b/CMSIS-SVD/SiFive/FE310.svd
@@ -752,195 +752,10 @@
       <registers>
 
         <register>
-          <name>R0</name>
-          <description>Backup Register 0.</description>
+	  	  <dim>32</dim>
+	  	  <dimIncrement>4</dimIncrement>
+          <name>Backup[%s]</name>
           <addressOffset>0x00</addressOffset>
-        </register>
-
-        <register>
-          <name>R1</name>
-          <description>Backup Register 1.</description>
-          <addressOffset>0x04</addressOffset>
-        </register>
-
-        <register>
-          <name>R2</name>
-          <description>Backup Register 2.</description>
-          <addressOffset>0x08</addressOffset>
-        </register>
-
-        <register>
-          <name>R3</name>
-          <description>Backup Register 3.</description>
-          <addressOffset>0x0C</addressOffset>
-        </register>
-
-        <register>
-          <name>R4</name>
-          <description>Backup Register 4.</description>
-          <addressOffset>0x10</addressOffset>
-        </register>
-
-        <register>
-          <name>R5</name>
-          <description>Backup Register 5.</description>
-          <addressOffset>0x14</addressOffset>
-        </register>
-
-        <register>
-          <name>R6</name>
-          <description>Backup Register 6.</description>
-          <addressOffset>0x18</addressOffset>
-        </register>
-
-        <register>
-          <name>R7</name>
-          <description>Backup Register 7.</description>
-          <addressOffset>0x1C</addressOffset>
-        </register>
-
-        <register>
-          <name>R8</name>
-          <description>Backup Register 8.</description>
-          <addressOffset>0x20</addressOffset>
-        </register>
-
-        <register>
-          <name>R9</name>
-          <description>Backup Register 9.</description>
-          <addressOffset>0x24</addressOffset>
-        </register>
-
-        <register>
-          <name>R10</name>
-          <description>Backup Register 10.</description>
-          <addressOffset>0x28</addressOffset>
-        </register>
-
-        <register>
-          <name>R11</name>
-          <description>Backup Register 11.</description>
-          <addressOffset>0x2C</addressOffset>
-        </register>
-
-        <register>
-          <name>R12</name>
-          <description>Backup Register 12.</description>
-          <addressOffset>0x30</addressOffset>
-        </register>
-
-        <register>
-          <name>R13</name>
-          <description>Backup Register 13.</description>
-          <addressOffset>0x34</addressOffset>
-        </register>
-
-        <register>
-          <name>R14</name>
-          <description>Backup Register 14.</description>
-          <addressOffset>0x38</addressOffset>
-        </register>
-
-        <register>
-          <name>R15</name>
-          <description>Backup Register 15.</description>
-          <addressOffset>0x3C</addressOffset>
-        </register>
-
-        <register>
-          <name>R16</name>
-          <description>Backup Register 16.</description>
-          <addressOffset>0x40</addressOffset>
-        </register>
-
-        <register>
-          <name>R17</name>
-          <description>Backup Register 17.</description>
-          <addressOffset>0x44</addressOffset>
-        </register>
-
-        <register>
-          <name>R18</name>
-          <description>Backup Register 18.</description>
-          <addressOffset>0x48</addressOffset>
-        </register>
-
-        <register>
-          <name>R19</name>
-          <description>Backup Register 19.</description>
-          <addressOffset>0x4C</addressOffset>
-        </register>
-
-        <register>
-          <name>R20</name>
-          <description>Backup Register 20.</description>
-          <addressOffset>0x50</addressOffset>
-        </register>
-
-        <register>
-          <name>R21</name>
-          <description>Backup Register 21.</description>
-          <addressOffset>0x54</addressOffset>
-        </register>
-
-        <register>
-          <name>R22</name>
-          <description>Backup Register 22.</description>
-          <addressOffset>0x58</addressOffset>
-        </register>
-
-        <register>
-          <name>R23</name>
-          <description>Backup Register 23.</description>
-          <addressOffset>0x5C</addressOffset>
-        </register>
-
-        <register>
-          <name>R24</name>
-          <description>Backup Register 24.</description>
-          <addressOffset>0x60</addressOffset>
-        </register>
-
-        <register>
-          <name>R25</name>
-          <description>Backup Register 25.</description>
-          <addressOffset>0x64</addressOffset>
-        </register>
-
-        <register>
-          <name>R26</name>
-          <description>Backup Register 26.</description>
-          <addressOffset>0x68</addressOffset>
-        </register>
-
-        <register>
-          <name>R27</name>
-          <description>Backup Register 27.</description>
-          <addressOffset>0x6C</addressOffset>
-        </register>
-
-        <register>
-          <name>R28</name>
-          <description>Backup Register 28.</description>
-          <addressOffset>0x70</addressOffset>
-        </register>
-
-        <register>
-          <name>R29</name>
-          <description>Backup Register 29.</description>
-          <addressOffset>0x74</addressOffset>
-        </register>
-
-        <register>
-          <name>R30</name>
-          <description>Backup Register 30.</description>
-          <addressOffset>0x78</addressOffset>
-        </register>
-
-        <register>
-          <name>R31</name>
-          <description>Backup Register 31.</description>
-          <addressOffset>0x7C</addressOffset>
         </register>
 
       </registers>
@@ -963,99 +778,19 @@
       <registers>
 
         <register>
-          <name>WAKEUPI0</name>
-          <description>Wakeup program instruction 0.</description>
+	  	  <dim>8</dim>
+	  	  <dimIncrement>4</dimIncrement>
+          <name>WAKEUPI[%s]</name>
+          <description>Wakeup program instructions.</description>
           <addressOffset>0x00</addressOffset>
         </register>
 
         <register>
-          <name>WAKEUPI1</name>
-          <description>Wakeup program instruction 1.</description>
-          <addressOffset>0x04</addressOffset>
-        </register>
-
-        <register>
-          <name>WAKEUPI2</name>
-          <description>Wakeup program instruction 2.</description>
-          <addressOffset>0x08</addressOffset>
-        </register>
-
-        <register>
-          <name>WAKEUPI3</name>
-          <description>Wakeup program instruction 3.</description>
-          <addressOffset>0x0C</addressOffset>
-        </register>
-
-        <register>
-          <name>WAKEUPI4</name>
-          <description>Wakeup program instruction 4.</description>
-          <addressOffset>0x10</addressOffset>
-        </register>
-
-        <register>
-          <name>WAKEUPI5</name>
-          <description>Wakeup program instruction 5.</description>
-          <addressOffset>0x14</addressOffset>
-        </register>
-
-        <register>
-          <name>WAKEUPI6</name>
-          <description>Wakeup program instruction 6.</description>
-          <addressOffset>0x18</addressOffset>
-        </register>
-
-        <register>
-          <name>WAKEUPI7</name>
-          <description>Wakeup program instruction 7.</description>
-          <addressOffset>0x1C</addressOffset>
-        </register>
-
-        <register>
-          <name>SLEEPI0</name>
-          <description>Sleep program instruction 0.</description>
+	  	  <dim>8</dim>
+	  	  <dimIncrement>4</dimIncrement>
+          <name>SLEEPI[%s]</name>
+          <description>Sleep program instructions.</description>
           <addressOffset>0x20</addressOffset>
-        </register>
-
-        <register>
-          <name>SLEEPI1</name>
-          <description>Sleep program instruction 1.</description>
-          <addressOffset>0x24</addressOffset>
-        </register>
-
-        <register>
-          <name>SLEEPI2</name>
-          <description>Sleep program instruction 2.</description>
-          <addressOffset>0x28</addressOffset>
-        </register>
-
-        <register>
-          <name>SLEEPI3</name>
-          <description>Sleep program instruction 3.</description>
-          <addressOffset>0x2C</addressOffset>
-        </register>
-
-        <register>
-          <name>SLEEPI4</name>
-          <description>Sleep program instruction 4.</description>
-          <addressOffset>0x30</addressOffset>
-        </register>
-
-        <register>
-          <name>SLEEPI5</name>
-          <description>Sleep program instruction 5.</description>
-          <addressOffset>0x34</addressOffset>
-        </register>
-
-        <register>
-          <name>SLEEPI6</name>
-          <description>Sleep program instruction 6.</description>
-          <addressOffset>0x38</addressOffset>
-        </register>
-
-        <register>
-          <name>SLEEPI7</name>
-          <description>Sleep program instruction 7.</description>
-          <addressOffset>0x3C</addressOffset>
         </register>
 
         <register>

--- a/CMSIS-SVD/SiFive/FE310.svd
+++ b/CMSIS-SVD/SiFive/FE310.svd
@@ -22,6 +22,75 @@
   <peripherals>
 
     <peripheral>
+      <name>PLIC</name>
+      <description>Platform-Level Interrupt Controller.</description>
+      <baseAddress>0x0C000000</baseAddress>
+      <groupName>PLIC</groupName>
+      <size>32</size>
+      <access>read-write</access>
+
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x200008</size>
+        <usage>registers</usage>
+      </addressBlock>
+
+      <registers>
+
+        <register>
+          <dim>52</dim>
+          <dimIncrement>4</dimIncrement>
+          <name>PRIORITY[%s]</name>
+          <description>PLIC Interrupt Priority Register.</description>
+          <addressOffset>0x000000</addressOffset>
+          <fields>
+            <field><name>PRIORITY</name><lsb>0</lsb><msb>2</msb></field>
+          </fields>
+        </register>
+
+        <register>
+          <name>PENDING_1</name>
+          <description>PLIC Interrupt Pending Register 1.</description>
+          <addressOffset>0x001000</addressOffset>
+        </register>
+
+        <register>
+          <name>PENDING_2</name>
+          <description>PLIC Interrupt Pending Register 2.</description>
+          <addressOffset>0x001004</addressOffset>
+        </register>
+
+        <register>
+          <name>ENABLE_1</name>
+          <description>PLIC Interrupt Enable Register 1.</description>
+          <addressOffset>0x002000</addressOffset>
+        </register>
+
+        <register>
+          <name>ENABLE_2</name>
+          <description>PLIC Interrupt Enable Register 2.</description>
+          <addressOffset>0x002004</addressOffset>
+        </register>
+        
+        <register>
+          <name>THRESHOLD</name>
+          <description>PLIC Interrupt Priority Threshold Register.</description>
+          <addressOffset>0x200000</addressOffset>
+          <fields>
+            <field><name>THRESHOLD</name><lsb>0</lsb><msb>2</msb></field>
+          </fields>
+        </register>
+
+        <register>
+          <name>CLAIM</name>
+          <description>PLIC Claim/Complete Register.</description>
+          <addressOffset>0x200004</addressOffset>
+        </register>
+
+      </registers>
+    </peripheral> <!-- PLIC -->
+
+    <peripheral>
       <name>CLINT</name>
       <description>Core Local Interruptor.</description>
       <baseAddress>0x02000000</baseAddress>
@@ -84,6 +153,39 @@
         <usage>registers</usage>
       </addressBlock>
 
+      <interrupt><name>GPIO_0_IRQ</name><value>8</value></interrupt>
+      <interrupt><name>GPIO_1_IRQ</name><value>9</value></interrupt>
+      <interrupt><name>GPIO_2_IRQ</name><value>10</value></interrupt>
+      <interrupt><name>GPIO_3_IRQ</name><value>11</value></interrupt>
+      <interrupt><name>GPIO_4_IRQ</name><value>12</value></interrupt>
+      <interrupt><name>GPIO_5_IRQ</name><value>13</value></interrupt>
+      <interrupt><name>GPIO_6_IRQ</name><value>14</value></interrupt>
+      <interrupt><name>GPIO_7_IRQ</name><value>15</value></interrupt>
+      <interrupt><name>GPIO_8_IRQ</name><value>16</value></interrupt>
+      <interrupt><name>GPIO_9_IRQ</name><value>17</value></interrupt>
+      <interrupt><name>GPIO_10_IRQ</name><value>18</value></interrupt>
+      <interrupt><name>GPIO_11_IRQ</name><value>19</value></interrupt>
+      <interrupt><name>GPIO_12_IRQ</name><value>20</value></interrupt>
+      <interrupt><name>GPIO_12_IRQ</name><value>21</value></interrupt>
+      <interrupt><name>GPIO_14_IRQ</name><value>22</value></interrupt>
+      <interrupt><name>GPIO_14_IRQ</name><value>23</value></interrupt>
+      <interrupt><name>GPIO_16_IRQ</name><value>24</value></interrupt>
+      <interrupt><name>GPIO_17_IRQ</name><value>25</value></interrupt>
+      <interrupt><name>GPIO_18_IRQ</name><value>26</value></interrupt>
+      <interrupt><name>GPIO_19_IRQ</name><value>27</value></interrupt>
+      <interrupt><name>GPIO_20_IRQ</name><value>28</value></interrupt>
+      <interrupt><name>GPIO_21_IRQ</name><value>29</value></interrupt>
+      <interrupt><name>GPIO_22_IRQ</name><value>30</value></interrupt>
+      <interrupt><name>GPIO_23_IRQ</name><value>31</value></interrupt>
+      <interrupt><name>GPIO_24_IRQ</name><value>32</value></interrupt>
+      <interrupt><name>GPIO_25_IRQ</name><value>33</value></interrupt>
+      <interrupt><name>GPIO_26_IRQ</name><value>34</value></interrupt>
+      <interrupt><name>GPIO_27_IRQ</name><value>35</value></interrupt>
+      <interrupt><name>GPIO_28_IRQ</name><value>36</value></interrupt>
+      <interrupt><name>GPIO_28_IRQ</name><value>37</value></interrupt>
+      <interrupt><name>GPIO_30_IRQ</name><value>38</value></interrupt>
+      <interrupt><name>GPIO_31_IRQ</name><value>39</value></interrupt>
+      
       <registers>
         <register>
           <name>VALUE</name>
@@ -220,6 +322,8 @@
         <size>0x1000</size>
         <usage>registers</usage>
       </addressBlock>
+
+      <interrupt><name>QSPI0_IRQ</name><value>5</value></interrupt>
 
       <registers>
 
@@ -497,15 +601,17 @@
       <name>QSPI1</name>
       <description>Serial Peripheral Interface.</description>
       <baseAddress>0x10024000</baseAddress>
-      <groupName>UART</groupName>
+      <groupName>SPI</groupName>
+      <interrupt><name>QSPI1_IRQ</name><value>6</value></interrupt>
     </peripheral> <!-- QSPI1 -->
 
     <peripheral derivedFrom="QSPI0">
       <name>QSPI2</name>
       <description>Serial Peripheral Interface.</description>
       <baseAddress>0x10034000</baseAddress>
-      <groupName>UART</groupName>
-    </peripheral> <!-- QSPI1 -->
+      <groupName>SPI</groupName>
+      <interrupt><name>QSPI2_IRQ</name><value>7</value></interrupt>
+    </peripheral> <!-- QSPI2 -->
 
     <peripheral>
       <name>UART0</name>
@@ -520,6 +626,8 @@
         <size>0x1000</size>
         <usage>registers</usage>
       </addressBlock>
+
+      <interrupt><name>UART0_IRQ</name><value>3</value></interrupt>
 
       <registers>
         <register>
@@ -589,6 +697,7 @@
       <description>Universal Asynchronous Receiver/Transmitter.</description>
       <baseAddress>0x10023000</baseAddress>
       <groupName>UART</groupName>
+      <interrupt><name>UART1_IRQ</name><value>4</value></interrupt>
     </peripheral> <!-- UART1 -->
 
     <peripheral>
@@ -604,6 +713,11 @@
         <size>0x1000</size>
         <usage>registers</usage>
       </addressBlock>
+
+      <interrupt><name>PWMO_CMP0_IRQ</name><value>40</value></interrupt>
+      <interrupt><name>PWMO_CMP1_IRQ</name><value>41</value></interrupt>
+      <interrupt><name>PWMO_CMP2_IRQ</name><value>42</value></interrupt>
+      <interrupt><name>PWMO_CMP3_IRQ</name><value>43</value></interrupt>
 
       <registers>
         <register>
@@ -680,11 +794,19 @@
       <name>PWM1</name>
       <baseAddress>0x10025000</baseAddress>
       <groupName>PWM</groupName>
+      <interrupt><name>PWM1_CMP0_IRQ</name><value>44</value></interrupt>
+      <interrupt><name>PWM1_CMP1_IRQ</name><value>45</value></interrupt>
+      <interrupt><name>PWM1_CMP2_IRQ</name><value>46</value></interrupt>
+      <interrupt><name>PWM1_CMP3_IRQ</name><value>47</value></interrupt>
     </peripheral> <!-- PWM1 -->
     <peripheral derivedFrom="PWM0">
       <name>PWM2</name>
       <baseAddress>0x10035000</baseAddress>
       <groupName>PWM</groupName>
+      <interrupt><name>PWM2_CMP0_IRQ</name><value>48</value></interrupt>
+      <interrupt><name>PWM2_CMP1_IRQ</name><value>49</value></interrupt>
+      <interrupt><name>PWM2_CMP2_IRQ</name><value>50</value></interrupt>
+      <interrupt><name>PWM2_CMP3_IRQ</name><value>51</value></interrupt>
     </peripheral> <!-- PWM2 -->
 
     <peripheral>
@@ -700,6 +822,8 @@
         <size>0x40</size>
         <usage>registers</usage>
       </addressBlock>
+
+      <interrupt><name>Watchdog_IRQ</name><value>1</value></interrupt>
 
       <registers>
 
@@ -771,6 +895,8 @@
         <size>0x30</size>
         <usage>registers</usage>
       </addressBlock>
+
+      <interrupt><name>RTC_IRQ</name><value>2</value></interrupt>
 
       <registers>
 

--- a/CMSIS-SVD/SiFive/FE310.svd
+++ b/CMSIS-SVD/SiFive/FE310.svd
@@ -626,9 +626,6 @@
           <name>LO</name>
           <description>RTC Count Register Low.</description>
           <addressOffset>0x048</addressOffset>
-          <fields>
-            <field><name>CNT</name><lsb>0</lsb><msb>31</msb></field>
-          </fields>
         </register>
 
         <register>
@@ -646,18 +643,12 @@
           <name>SCALE_COUNT</name>
           <description>RTC Scaled Counter Register.</description>
           <addressOffset>0x050</addressOffset>
-          <fields>
-            <field><name>CNT</name><lsb>0</lsb><msb>15</msb></field>
-          </fields>
         </register>
 
         <register>
           <name>COMPARE</name>
           <description>RTC Compare Register.</description>
           <addressOffset>0x060</addressOffset>
-          <fields>
-            <field><name>CMP</name><lsb>0</lsb><msb>31</msb></field>
-          </fields>
         </register>
 
       </registers>


### PR DESCRIPTION
- Add registers definitions for PLIC, CLINT, SPI, WDT, RTC, LF Oscillator, Backup Registers and PMU.
- Add peripherals interrupts definitions.
- Fix a copy-paste error in the device <series> tag.
- Fix a typo in the PWM scaled count register description.