### PR TITLE
SiFive: add missing addressOffset to the PLIC ENABLE register

### DIFF
--- a/CMSIS-SVD/SiFive/FE310.svd
+++ b/CMSIS-SVD/SiFive/FE310.svd
@@ -257,6 +257,7 @@
             <dimIncrement>4</dimIncrement>
             <name>ENABLE[%s]</name>
             <description>PLIC Interrupt Enable Register.</description>
+            <addressOffset>0x0</addressOffset>
             <fields>
               <field><name>INT0</name><lsb>0</lsb><msb>0</msb></field>
               <field><name>INT1</name><lsb>1</lsb><msb>1</msb></field>


### PR DESCRIPTION
I have been trying to parse this SVD file with a tool I've written and found that this is the only file that misses an `addressOffset` inside a `<register>`. In fact, it looks like this field is required by the spec: https://www.keil.com/pack/doc/CMSIS/SVD/html/elem_registers.html#elem_register