### PR TITLE
Eliminate some warnings.

### DIFF
--- a/src/ada_gen.adb
+++ b/src/ada_gen.adb
@@ -2,7 +2,7 @@
 --                                                                          --
 --                          SVD Binding Generator                           --
 --                                                                          --
---                    Copyright (C) 2015-2019, AdaCore                      --
+--                    Copyright (C) 2015-2020, AdaCore                      --
 --                                                                          --
 -- SVD2Ada is free software;  you can  redistribute it  and/or modify it    --
 -- under terms of the  GNU General Public License as published  by the Free --
@@ -1174,8 +1174,6 @@ package body Ada_Gen is
          Ada.Text_IO.New_Line (F);
       end if;
 
-      Ada.Text_IO.Put_Line
-        (F, "pragma Ada_2012;");
       Ada.Text_IO.Put_Line (F, "pragma Style_Checks (Off);");
       Ada.Text_IO.New_Line (F);
 

--- a/src/ada_gen.adb
+++ b/src/ada_gen.adb
@@ -1174,6 +1174,11 @@ package body Ada_Gen is
          Ada.Text_IO.New_Line (F);
       end if;
 
+      Ada.Text_IO.Put_Line
+        (F, "pragma Ada_2012;");
+      Ada.Text_IO.Put_Line (F, "pragma Style_Checks (Off);");
+      Ada.Text_IO.New_Line (F);
+
       if Length (Trim (G_License_Text, Both)) > 0 then
          Ada.Text_IO.Put_Line (F, To_String (G_License_Text));
          Ada.Text_IO.New_Line (F);
@@ -1194,9 +1199,6 @@ package body Ada_Gen is
               (F, "pragma Restrictions (No_Elaboration_Code);");
          end if;
 
-         Ada.Text_IO.Put_Line
-           (F, "pragma Ada_2012;");
-         Ada.Text_IO.Put_Line (F, "pragma Style_Checks (Off);");
          Ada.Text_IO.New_Line (F);
          G_Empty_Line := True;
       end if;
@@ -1756,7 +1758,7 @@ package body Ada_Gen is
    is
    begin
       if Element.Size in 8 | 16 | 32 | 64 then
-         Add (Spec, New_With_Clause ("Interfaces", True));
+         Add (Spec, New_With_Clause ("Interfaces", Use_Visible => False));
       end if;
    end Added_In_Spec;
 


### PR DESCRIPTION
These changes result from #59 and #60 .

I realise that they are independent, and you may want to have separate pull requests; I’d actually forgotten that I’d raised the issues before committing the change.

In particular, on #59, Pat was concerned whether child packages might depend on the `use Interfaces`; test generations/compilations (STM32F4, Arduino Due) were OK.

  * src/ada_gen.adb (Write_Spec): specify Ada_2012 (why?), suppress
      style checks, even if not preelaborated. Has the added effect
      of suppressing style checks in the license text.
    (Added_In_Spec): if Interfaces is required, don't 'use' it.