### PR TITLE
Added 'Create_Missing_Dirs' option

### DIFF
--- a/svd2ada.gpr
+++ b/svd2ada.gpr
@@ -9,6 +9,7 @@ project SVD2Ada is
    for Main use ("svd2ada.adb");
    for Object_Dir use "obj/" & Build;
    for Exec_Dir use ".";
+   for Create_Missing_Dirs use "True";
 
    package Builder is
       for Default_Switches ("ada") use ("-s");


### PR DESCRIPTION
I've added the `for Create_Missing_Dirs use True;` option to svd2ada.gpr. Building svd2ada right after cloning the repository causes the compilation to fail with gprbuild complaining that object directory "obj/release" was not found.