### PR TITLE
Add Node full name to WARNING messages.

### DIFF
--- a/src/base_types.adb
+++ b/src/base_types.adb
@@ -676,18 +676,19 @@ package body Base_Types is
    -- Get_Full_Name --
    -------------------
 
-   function Get_Full_Name (Elt : DOM.Core.Node) return String
+   function Full_Name (Elt : DOM.Core.Node) return String
    is
       Parent : constant DOM.Core.Node := DOM.Core.Nodes.Parent_Node (Elt);
       Str    : Ada.Strings.Unbounded.Unbounded_String;
    begin
 
       if Parent /= null then
-         Str := Ada.Strings.Unbounded.To_Unbounded_String (Get_Full_Name (Parent));
+         Str := Ada.Strings.Unbounded.To_Unbounded_String (Full_Name (Parent));
       else
          Str := Ada.Strings.Unbounded.To_Unbounded_String ("");
       end if;
 
+      --  Search for "name" tag and add it's content to Str
       declare
          Children_List : constant DOM.Core.Node_List := DOM.Core.Nodes.Child_Nodes (Elt);
       begin
@@ -704,6 +705,6 @@ package body Base_Types is
       end;
 
       return Ada.Strings.Unbounded.To_String (Str);
-   end Get_Full_Name;
+   end Full_Name;
 
 end Base_Types;

--- a/src/base_types.adb
+++ b/src/base_types.adb
@@ -28,6 +28,8 @@ package body Base_Types is
 
    package Unsigned_IO is new Ada.Text_IO.Modular_IO (Unsigned);
 
+   use type DOM.Core.Node;
+
    procedure Read_Range_Elts
      (Tag : String;
       Elt : DOM.Core.Element;
@@ -669,5 +671,39 @@ package body Base_Types is
 
       return To_Unbounded_String (Slice (Name1, 1, Prefix));
    end Common_Prefix;
+
+   -------------------
+   -- Get_Full_Name --
+   -------------------
+
+   function Get_Full_Name (Elt : DOM.Core.Node) return String
+   is
+      Parent : constant DOM.Core.Node := DOM.Core.Nodes.Parent_Node (Elt);
+      Str    : Ada.Strings.Unbounded.Unbounded_String;
+   begin
+
+      if Parent /= null then
+         Str := Ada.Strings.Unbounded.To_Unbounded_String (Get_Full_Name (Parent));
+      else
+         Str := Ada.Strings.Unbounded.To_Unbounded_String ("");
+      end if;
+
+      declare
+         Children_List : constant DOM.Core.Node_List := DOM.Core.Nodes.Child_Nodes (Elt);
+      begin
+         for N in 0 .. DOM.Core.Nodes.Length (Children_List) - 1 loop
+            declare
+               Child_Node : constant DOM.Core.Node := DOM.Core.Nodes.Item (Children_List, N);
+               Text : String renames DOM.Core.Nodes.Node_Name (Child_Node);
+            begin
+               if Text = "name" then
+                  Ada.Strings.Unbounded.Append (Str, "/" & Get_Value (Child_Node));
+               end if;
+            end;
+         end loop;
+      end;
+
+      return Ada.Strings.Unbounded.To_String (Str);
+   end Get_Full_Name;
 
 end Base_Types;

--- a/src/base_types.ads
+++ b/src/base_types.ads
@@ -194,6 +194,6 @@ package Base_Types is
    --  Returns the prefix common to Name1 and Name2 if any, or
    --  Null_Unbounded_String
 
-   function Get_Full_Name (Elt : DOM.Core.Node) return String;
+   function Full_Name (Elt : DOM.Core.Node) return String;
 
 end Base_Types;

--- a/src/base_types.ads
+++ b/src/base_types.ads
@@ -194,4 +194,6 @@ package Base_Types is
    --  Returns the prefix common to Name1 and Name2 if any, or
    --  Null_Unbounded_String
 
+   function Get_Full_Name (Elt : DOM.Core.Node) return String;
+
 end Base_Types;

--- a/src/descriptors-cluster.adb
+++ b/src/descriptors-cluster.adb
@@ -167,7 +167,7 @@ package body Descriptors.Cluster is
 
                else
                   Ada.Text_IO.Put_Line
-                    ("*** WARNING: ignoring cluster element " & Tag);
+                    ("*** WARNING: ignoring cluster element " & Tag & " at " & Get_Full_Name (Child));
                end if;
             end;
          end if;

--- a/src/descriptors-cluster.adb
+++ b/src/descriptors-cluster.adb
@@ -167,7 +167,7 @@ package body Descriptors.Cluster is
 
                else
                   Ada.Text_IO.Put_Line
-                    ("*** WARNING: ignoring cluster element " & Tag & " at " & Get_Full_Name (Child));
+                    ("*** WARNING: ignoring cluster element " & Tag & " at " & Full_Name (Child));
                end if;
             end;
          end if;

--- a/src/descriptors-device.adb
+++ b/src/descriptors-device.adb
@@ -164,7 +164,7 @@ package body Descriptors.Device is
 
                else
                   Ada.Text_IO.Put_Line
-                    ("*** WARNING: ignoring device element " & Tag);
+                    ("*** WARNING: ignoring device element " & Tag & " at " & Get_Full_Name (Child));
                end if;
             end;
          end if;

--- a/src/descriptors-device.adb
+++ b/src/descriptors-device.adb
@@ -164,7 +164,7 @@ package body Descriptors.Device is
 
                else
                   Ada.Text_IO.Put_Line
-                    ("*** WARNING: ignoring device element " & Tag & " at " & Get_Full_Name (Child));
+                    ("*** WARNING: ignoring device element " & Tag & " at " & Full_Name (Child));
                end if;
             end;
          end if;

--- a/src/descriptors-enumerate.adb
+++ b/src/descriptors-enumerate.adb
@@ -123,7 +123,8 @@ package body Descriptors.Enumerate is
                   Result.IsDefault := True;
 
                else
-                  Ada.Text_IO.Put_Line ("*** WARNING: ignoring enumerate element " & Tag);
+                  Ada.Text_IO.Put_Line ("*** WARNING: ignoring enumerate element " & Tag & " at " &
+                                          Get_Full_Name (Child));
                end if;
             end;
          end if;
@@ -184,7 +185,8 @@ package body Descriptors.Enumerate is
                   Read_Value (Child, Write_Only, Result.Values);
 
                else
-                  Ada.Text_IO.Put_Line ("*** WARNING: ignoring enumerate element " & Tag);
+                  Ada.Text_IO.Put_Line ("*** WARNING: ignoring enumerate element " & Tag & " at " &
+                                          Get_Full_Name (Child));
                end if;
             end;
          end if;

--- a/src/descriptors-enumerate.adb
+++ b/src/descriptors-enumerate.adb
@@ -123,8 +123,7 @@ package body Descriptors.Enumerate is
                   Result.IsDefault := True;
 
                else
-                  Ada.Text_IO.Put_Line ("*** WARNING: ignoring enumerate element " & Tag & " at " &
-                                          Get_Full_Name (Child));
+                  Ada.Text_IO.Put_Line ("*** WARNING: ignoring enumerate element " & Tag & " at " & Full_Name (Child));
                end if;
             end;
          end if;
@@ -185,8 +184,7 @@ package body Descriptors.Enumerate is
                   Read_Value (Child, Write_Only, Result.Values);
 
                else
-                  Ada.Text_IO.Put_Line ("*** WARNING: ignoring enumerate element " & Tag & " at " &
-                                          Get_Full_Name (Child));
+                  Ada.Text_IO.Put_Line ("*** WARNING: ignoring enumerate element " & Tag & " at " & Full_Name (Child));
                end if;
             end;
          end if;

--- a/src/descriptors-field.adb
+++ b/src/descriptors-field.adb
@@ -135,7 +135,7 @@ package body Descriptors.Field is
 
                else
                   Ada.Text_IO.Put_Line
-                    ("*** WARNING: ignoring field element " & Tag);
+                    ("*** WARNING: ignoring field element " & Tag & " at " & Get_Full_Name (Child));
                end if;
             end;
          end if;

--- a/src/descriptors-field.adb
+++ b/src/descriptors-field.adb
@@ -135,7 +135,7 @@ package body Descriptors.Field is
 
                else
                   Ada.Text_IO.Put_Line
-                    ("*** WARNING: ignoring field element " & Tag & " at " & Get_Full_Name (Child));
+                    ("*** WARNING: ignoring field element " & Tag & " at " & Full_Name (Child));
                end if;
             end;
          end if;

--- a/src/descriptors-peripheral.adb
+++ b/src/descriptors-peripheral.adb
@@ -248,7 +248,7 @@ package body Descriptors.Peripheral is
 
                else
                   Ada.Text_IO.Put_Line
-                    ("*** WARNING: ignoring peripheral element " & Tag & " at " & Get_Full_Name (Child));
+                    ("*** WARNING: ignoring peripheral element " & Tag & " at " & Full_Name (Child));
                end if;
             end;
          end if;

--- a/src/descriptors-peripheral.adb
+++ b/src/descriptors-peripheral.adb
@@ -248,7 +248,7 @@ package body Descriptors.Peripheral is
 
                else
                   Ada.Text_IO.Put_Line
-                    ("*** WARNING: ignoring peripheral element " & Tag);
+                    ("*** WARNING: ignoring peripheral element " & Tag & " at " & Get_Full_Name (Child));
                end if;
             end;
          end if;

--- a/src/descriptors-register.adb
+++ b/src/descriptors-register.adb
@@ -180,7 +180,7 @@ package body Descriptors.Register is
 
                else
                   Ada.Text_IO.Put_Line
-                    ("*** WARNING: ignoring register element " & Tag & " at " & Get_Full_Name (Child));
+                    ("*** WARNING: ignoring register element " & Tag & " at " & Full_Name (Child));
                end if;
             end;
          end if;

--- a/src/descriptors-register.adb
+++ b/src/descriptors-register.adb
@@ -180,7 +180,7 @@ package body Descriptors.Register is
 
                else
                   Ada.Text_IO.Put_Line
-                    ("*** WARNING: ignoring register element " & Tag);
+                    ("*** WARNING: ignoring register element " & Tag & " at " & Get_Full_Name (Child));
                end if;
             end;
          end if;


### PR DESCRIPTION
For example, this is very usefull when a SVD file is malformed and simply displays : "*** WARNING: ignoring field element enumeratedValue".
Now, it displays something like : "*** WARNING: ignoring field element enumeratedValue at /MIMXRT1021/XTALOSC24M/OSC_CONFIG2/MUX_1M/LOCKED_1MHZ"