### PR TITLE
Removed unused packages

### DIFF
--- a/src/descriptors-peripheral.adb
+++ b/src/descriptors-peripheral.adb
@@ -18,7 +18,6 @@
 ------------------------------------------------------------------------------
 
 with Ada.Text_IO;
-with Ada.Containers.Indefinite_Vectors;
 
 with DOM.Core;
 with DOM.Core.Elements;  use DOM.Core.Elements;
@@ -37,9 +36,6 @@ package body Descriptors.Peripheral is
 
    package Peripheral_Sort is new Peripheral_Vectors.Generic_Sorting
      (Less);
-
-   package String_List is new Ada.Containers.Indefinite_Vectors
-     (Positive, String);
 
    procedure Dump_Periph_Type
      (Spec       : in out Ada_Gen.Ada_Spec;


### PR DESCRIPTION
svd2ada does not compiles without modification. It compiles when I remove theses lines.

Here is the compilation error I was getting before I made the changes.

> $ gprbuild -P svd2ada.gpr
Setup
   [mkdir]        object directory for project SVD2Ada
Compile
   [Ada]          svd2ada.adb
   [Ada]          ada_gen.adb
   [Ada]          descriptors.ads
   [Ada]          descriptors-device.adb
   [Ada]          svd2ada_utils.adb
   [Ada]          base_types.adb
   [Ada]          base_types-register_properties.adb
   [Ada]          descriptors-peripheral.adb
descriptors-peripheral.adb:41:12: warning: package "String_List" is not referenced [-gnatwu]
gprbuild: *** compilation phase failed
