### PR TITLE
Fix MSB before LSB

### DIFF
--- a/src/descriptors-field.adb
+++ b/src/descriptors-field.adb
@@ -76,79 +76,83 @@ package body Descriptors.Field is
          end;
       end if;
 
-      for J in 0 .. Nodes.Length (List) - 1 loop
-         if Nodes.Node_Type (Nodes.Item (List, J)) = Element_Node then
-            declare
-               Child : constant Element := Element (Nodes.Item (List, J));
-               Tag   : String renames Elements.Get_Tag_Name (Child);
-               Size_Calculated : Bool := False;
-            begin
-               if Tag = "name" then
-                  Result.Name := Get_Value (Child);
+      declare
+         Size_Calculated : Boolean := False;
+      begin
+         for J in 0 .. Nodes.Length (List) - 1 loop
+            if Nodes.Node_Type (Nodes.Item (List, J)) = Element_Node then
+               declare
+                  Child : constant Element := Element (Nodes.Item (List, J));
+                  Tag   : String renames Elements.Get_Tag_Name (Child);
+               begin
+                  if Tag = "name" then
+                     Result.Name := Get_Value (Child);
 
-               elsif Tag = "description" then
-                  Result.Description := Get_Value (Child);
+                  elsif Tag = "description" then
+                     Result.Description := Get_Value (Child);
 
-               elsif Tag = "bitOffset"
-                 or else Tag = "lsb"
-               then
-                  Result.LSB := Get_Value (Child);
+                  elsif Tag = "bitOffset"
+                    or else Tag = "lsb"
+                  then
+                     Result.LSB := Get_Value (Child);
 
-               elsif Tag = "bitWidth" then
-                  Result.Size := Get_Value (Child);
-                  Size_Calculated := True;
-
-               elsif Tag = "msb" then
-                  Result.MSB := Get_Value (Child);
-
-               elsif Tag = "bitRange" then
-                  --  bitRange has the form: [XX:YY] where XX is the MSB,
-                  --  and YY is the LSB
-                  declare
-                     Val : String renames Get_Value (Child);
-                  begin
-                     for K in Val'Range loop
-                        if Val (K) = ':' then
-                           Result.LSB :=
-                             Natural'Value (Val (K + 1 .. Val'Last - 1));
-                           Result.Size :=
-                             Natural'Value (Val (2 .. K - 1)) - Result.LSB + 1;
-                        end if;
-                     end loop;
+                  elsif Tag = "bitWidth" then
+                     Result.Size := Get_Value (Child);
                      Size_Calculated := True;
-                  end;
 
-               elsif Tag = "access" then
-                  Result.Acc := Get_Value (Child);
+                  elsif Tag = "msb" then
+                     Result.MSB := Get_Value (Child);
 
-               elsif Tag = "modifiedWriteValues" then
-                  Result.Mod_Write_Values := Get_Value (Child);
+                  elsif Tag = "bitRange" then
+                     --  bitRange has the form: [XX:YY] where XX is the MSB,
+                     --  and YY is the LSB
+                     declare
+                        Val : String renames Get_Value (Child);
+                     begin
+                        for K in Val'Range loop
+                           if Val (K) = ':' then
+                              Result.LSB :=
+                                Natural'Value (Val (K + 1 .. Val'Last - 1));
+                              Result.Size :=
+                                Natural'Value (Val (2 .. K - 1)) - Result.LSB + 1;
+                           end if;
+                        end loop;
+                     end;
+                     Size_Calculated := True;
 
-               elsif Tag = "readAction" then
-                  Result.Read_Action := Get_Value (Child);
+                  elsif Tag = "access" then
+                     Result.Acc := Get_Value (Child);
 
-               elsif Tag = "enumeratedValues" then
-                  declare
-                     Enum : constant Descriptors.Enumerate.Enumerate_T :=
-                              Descriptors.Enumerate.Read_Enumerate
-                                (Child, Result.Enums, Result.Acc = Write_Only);
-                  begin
-                     Result.Enums.Append (Enum);
-                  end;
+                  elsif Tag = "modifiedWriteValues" then
+                     Result.Mod_Write_Values := Get_Value (Child);
 
-               else
-                  Ada.Text_IO.Put_Line
-                    ("*** WARNING: ignoring field element " & Tag & " at " & Full_Name (Child));
-               end if;
+                  elsif Tag = "readAction" then
+                     Result.Read_Action := Get_Value (Child);
 
-               --  Neither bitRange nor bitWidth has been used
-               if not Size_Calculated then
-                  Result.Size := Result.MSB - Result.LSB + 1;
-               end if;
+                  elsif Tag = "enumeratedValues" then
+                     declare
+                        Enum : constant Descriptors.Enumerate.Enumerate_T :=
+                          Descriptors.Enumerate.Read_Enumerate
+                            (Child, Result.Enums, Result.Acc = Write_Only);
+                     begin
+                        Result.Enums.Append (Enum);
+                     end;
 
-            end;
+                  else
+                     Ada.Text_IO.Put_Line
+                       ("*** WARNING: ignoring field element " & Tag & " at " & Full_Name (Child));
+                  end if;
+
+               end;
+            end if;
+         end loop;
+
+         --  Neither bitRange nor bitWidth has been used
+         if not Size_Calculated then
+            Result.Size := Result.MSB - Result.LSB + 1;
          end if;
-      end loop;
+
+      end;
 
       return Result;
    end Read_Field;

--- a/src/descriptors-field.adb
+++ b/src/descriptors-field.adb
@@ -81,6 +81,7 @@ package body Descriptors.Field is
             declare
                Child : constant Element := Element (Nodes.Item (List, J));
                Tag   : String renames Elements.Get_Tag_Name (Child);
+               Size_Calculated : Bool := False;
             begin
                if Tag = "name" then
                   Result.Name := Get_Value (Child);
@@ -95,9 +96,10 @@ package body Descriptors.Field is
 
                elsif Tag = "bitWidth" then
                   Result.Size := Get_Value (Child);
+                  Size_Calculated := True;
 
                elsif Tag = "msb" then
-                  Result.Size := Get_Value (Child) - Result.LSB + 1;
+                  Result.MSB := Get_Value (Child);
 
                elsif Tag = "bitRange" then
                   --  bitRange has the form: [XX:YY] where XX is the MSB,
@@ -113,6 +115,7 @@ package body Descriptors.Field is
                              Natural'Value (Val (2 .. K - 1)) - Result.LSB + 1;
                         end if;
                      end loop;
+                     Size_Calculated := True;
                   end;
 
                elsif Tag = "access" then
@@ -137,6 +140,12 @@ package body Descriptors.Field is
                   Ada.Text_IO.Put_Line
                     ("*** WARNING: ignoring field element " & Tag & " at " & Full_Name (Child));
                end if;
+
+               --  Neither bitRange nor bitWidth has been used
+               if not Size_Calculated then
+                  Result.Size := Result.MSB - Result.LSB + 1;
+               end if;
+
             end;
          end if;
       end loop;

--- a/src/descriptors-field.ads
+++ b/src/descriptors-field.ads
@@ -36,6 +36,7 @@ package Descriptors.Field is
       Name             : Unbounded.Unbounded_String;
       Description      : Unbounded.Unbounded_String;
       LSB              : Natural;
+      MSB              : Natural;
       Size             : Natural;
       Acc              : Access_Type;
       Mod_Write_Values : Modified_Write_Values_Type := Modify;
@@ -49,6 +50,7 @@ package Descriptors.Field is
    Null_Field : constant Field_T :=
                   (Unbounded.Null_Unbounded_String,
                    Unbounded.Null_Unbounded_String,
+                   0,
                    0,
                    0,
                    Read_Write,


### PR DESCRIPTION
This PR should fix #88 

I need this because Litex generates SVD files declaring MSB before LSB. Just a few lines had to be changed, however, due to a new declare affecting the whole loop, it seems much larger than needed.

PLEASE, test this with other SVDs. Nothing should have broken, but still. I cannot test the changes as I don't really have many SVDs at hand.

Pinging: @Fabien-Chouteau 

Best regards,
Fer