### PR TITLE
gprinstall installs the schema.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        os: [macos-12, windows-latest, ubuntu-latest]
         gnat_version: [^11]
         gprbuild_version: [^21]
     runs-on: ${{ matrix.os }}

--- a/svd2ada.gpr
+++ b/svd2ada.gpr
@@ -80,8 +80,11 @@ project SVD2ada is
    end Binder;
 
    package Install is
+      for Mode use "usage";
       for Required_Artifacts ("schema")
       use ("schema/CMSIS-SVD_Schema_1_3_1.xsd");
+      for Required_Artifacts ("share/CMSIS-SVD")
+      use ("CMSIS-SVD/");
    end Install;
 
 end SVD2ada;

--- a/svd2ada.gpr
+++ b/svd2ada.gpr
@@ -79,4 +79,9 @@ project SVD2ada is
       for Switches ("Ada") use ("-Es"); --  Symbolic traceback
    end Binder;
 
+   package Install is
+      for Required_Artifacts ("schema")
+      use ("schema/CMSIS-SVD_Schema_1_3_1.xsd");
+   end Install;
+
 end SVD2ada;


### PR DESCRIPTION
### For the first commit:

svd2ada requires the schema XSD file in `$prefix/schema/`, and there's no clear switch or environment variable to affect this.

When installing the project, as for example with "alr install svd2ada", make it so that the schema XSD file is installed too, where svd2ada will find it.

### For the second commit:

At present (2024-06-18), macos-latest runs on macos-14 (which is aarch64, but that doesn't affect this issue). The version of Xcode installed by default on the Github runner is 15.0.1, which has the linking bug (assertion failure in ld).

We could fix this by selecting a later version of Xcode (e.g.15.3), but at some point this issue will be fixed and we can revert to macos-latest. macos-13 has been updated to the same problematic Xcode. macos-12 uses Xcode 14, which doesn't have the problem, so running on macos-12 seems the simplest solution.