### PR TITLE
Install svds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,3 @@
-
-
 on:
   push:
   pull_request:
@@ -14,12 +12,10 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        gnat_version: [^11]
-        gprbuild_version: [^21]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: alire-project/setup-alire@v1
+      - uses: actions/checkout@v3
+      - uses: alire-project/setup-alire@v3
         with:
           toolchain: gprbuild${{ matrix.gprbuild_version }} gnat_native${{ matrix.gnat_version }} --disable-assistant
       - run: alr build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - uses: alire-project/setup-alire@v2
+      - uses: alire-project/setup-alire@v3
         with:
-          toolchain: gprbuild${{ matrix.gprbuild_version }} gnat_native${{ matrix.gnat_version }} --disable-assistant
+          toolchain: gnat_native${{ matrix.gnat_version }} gprbuild${{ matrix.gprbuild_version }} --disable-assistant
       - run: alr build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - uses: alire-project/setup-alire@v3
+      - uses: alire-project/setup-alire@v2
         with:
           toolchain: gprbuild${{ matrix.gprbuild_version }} gnat_native${{ matrix.gnat_version }} --disable-assistant
       - run: alr build

--- a/alire.toml
+++ b/alire.toml
@@ -1,6 +1,6 @@
 name = "svd2ada"
 description = "Ada binding generator from CMSIS-SVD hardware descriptions files"
-version = "0.1.0"
+version = "0.1.1"
 
 authors = ["AdaCore"]
 maintainers = ["Fabien Chouteau <fabien.chouteau@gmail.com>"]
@@ -9,7 +9,7 @@ maintainers-logins = ["Fabien-Chouteau"]
 executables = ["svd2ada"]
 
 [[depends-on]]
-xmlada = "^22.0.0"
+xmlada = ">=22.0.0"
 
 [configuration]
 disabled = true

--- a/svd2ada.gpr
+++ b/svd2ada.gpr
@@ -79,4 +79,10 @@ project SVD2ada is
       for Switches ("Ada") use ("-Es"); --  Symbolic traceback
    end Binder;
 
+   package Install is
+      for Mode use "usage";
+      for Required_Artifacts ("schema") use ("schema/");
+      for Required_Artifacts ("share/CMSIS-SVD") use ("CMSIS-SVD/");
+   end Install;
+
 end SVD2ada;


### PR DESCRIPTION
When installing via Alire, include the schema and the SVD files.

Also,  updated CI to use default tools, and newer actions (had a problem with setup-alire v3).