### PR TITLE
Fix CI; add dimensioned register fields

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,3 @@
-
-
 on:
   push:
   pull_request:
@@ -14,12 +12,10 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        gnat_version: [^11]
-        gprbuild_version: [^21]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: alire-project/setup-alire@v1
+      - uses: actions/checkout@v3
+      - uses: alire-project/setup-alire@v3
         with:
-          toolchain: gprbuild${{ matrix.gprbuild_version }} gnat_native${{ matrix.gnat_version }} --disable-assistant
+          toolchain: gnat_native${{ matrix.gnat_version }} gprbuild${{ matrix.gprbuild_version }} --disable-assistant
       - run: alr build

--- a/alire.toml
+++ b/alire.toml
@@ -1,6 +1,6 @@
 name = "svd2ada"
 description = "Ada binding generator from CMSIS-SVD hardware descriptions files"
-version = "0.1.0"
+version = "0.1.1"
 
 authors = ["AdaCore"]
 maintainers = ["Fabien Chouteau <fabien.chouteau@gmail.com>"]
@@ -9,7 +9,7 @@ maintainers-logins = ["Fabien-Chouteau"]
 executables = ["svd2ada"]
 
 [[depends-on]]
-xmlada = "^22.0.0"
+xmlada = ">=22.0.0"
 
 [configuration]
 disabled = true

--- a/src/ada_gen.adb
+++ b/src/ada_gen.adb
@@ -2,7 +2,7 @@
 --                                                                          --
 --                          SVD Binding Generator                           --
 --                                                                          --
---                    Copyright (C) 2015-2020, AdaCore                      --
+--                    Copyright (C) 2015-2024, AdaCore                      --
 --                                                                          --
 -- SVD2Ada is free software;  you can  redistribute it  and/or modify it    --
 -- under terms of the  GNU General Public License as published  by the Free --
@@ -1757,16 +1757,16 @@ package body Ada_Gen is
 
    function Get_Boolean return Ada_Type_Enum
    is
-      Result : Ada_Type_Enum;
-      Dead   : Ada_Enum_Value;
-      Dead2  : constant Ada_Spec := New_Spec ("Standard", "", False);
+      Result   : Ada_Type_Enum;
+      Dummy    : Ada_Enum_Value;
+      Dummy_2  : constant Ada_Spec := New_Spec ("Standard", "", False);
    begin
       Result := (Id      => To_Unbounded_String ("Boolean"),
                  Comment => New_Comment ("", False),
                  Aspects => <>,
                  Values  => <>);
-      Dead := Add_Enum_Id (Dead2, Result, "False", 0);
-      Dead := Add_Enum_Id (Dead2, Result, "True", 0);
+      Dummy := Add_Enum_Id (Dummy_2, Result, "False", 0);
+      Dummy := Add_Enum_Id (Dummy_2, Result, "True", 0);
 
       return Result;
    end Get_Boolean;

--- a/src/descriptors-field.adb
+++ b/src/descriptors-field.adb
@@ -299,18 +299,20 @@ package body Descriptors.Field is
                Replacement :
                declare
                   Candidate : Field_T := Original;
-                  Addition : Natural := D - 1;
-                  Index : Natural := Original.Index + Addition;
-                  LSB : Natural := Original.LSB + Original.Increment * Addition;
-                  MSB : Natural := Original.MSB + Original.Increment * Addition;
+                  Addition : constant Natural := D - 1;
+                  Index : constant Natural := Original.Index + Addition;
+                  LSB : constant Natural
+                    := Original.LSB + Original.Increment * Addition;
+                  MSB : constant Natural
+                    := Original.MSB + Original.Increment * Addition;
                begin
                   Substitute :
                   loop
                      declare
-                        Percent_S : Natural
+                        Percent_S : constant Natural
                           := Unbounded.Index (Candidate.Name, Pattern => "%s");
                      begin
-                        exit when Percent_S = 0;
+                        exit Substitute when Percent_S = 0;
                         Unbounded.Replace_Slice
                           (Candidate.Name,
                            Low  => Percent_S,
@@ -353,7 +355,8 @@ package body Descriptors.Field is
          end if;
       end Get_Default;
 
-      Fields        : array (0 .. Properties.Size - 1) of Field_T := (others => Null_Field);
+      Fields        : array (0 .. Properties.Size - 1) of Field_T
+        := (others => Null_Field);
       Index         : Natural;
       Index2        : Natural;
       Length        : Natural;
@@ -369,7 +372,7 @@ package body Descriptors.Field is
       All_RO        : Boolean := True;
       use Descriptors.Register;
 
-      Full_Fields : Field_Vectors.Vector
+      Full_Fields : constant Field_Vectors.Vector
         := Insert_Dimensioned_Fields (Reg_Fields);
 
    begin

--- a/src/descriptors-field.adb
+++ b/src/descriptors-field.adb
@@ -2,7 +2,7 @@
 --                                                                          --
 --                          SVD Binding Generator                           --
 --                                                                          --
---                    Copyright (C) 2015-2020, AdaCore                      --
+--                    Copyright (C) 2015-2024, AdaCore                      --
 --                                                                          --
 -- SVD2Ada is free software;  you can  redistribute it  and/or modify it    --
 -- under terms of the  GNU General Public License as published  by the Free --
@@ -18,6 +18,7 @@
 ------------------------------------------------------------------------------
 
 with Ada.Text_IO;
+with Ada.Strings.Fixed;
 with Interfaces;              use Interfaces;
 
 with DOM.Core;                use DOM.Core;
@@ -54,6 +55,9 @@ package body Descriptors.Field is
       Derived_From : constant String := Elements.Get_Attribute (Elt, "derivedFrom");
 
    begin
+      Result.Dimensions := 1;
+      Result.Increment := 0;
+      Result.Index := 0;
       Result.Acc := Default_Access;
       Result.Read_Action := Default_Read;
 
@@ -90,6 +94,27 @@ package body Descriptors.Field is
 
                   elsif Tag = "description" then
                      Result.Description := Get_Value (Child);
+
+                  elsif Tag = "dim" then
+                     Result.Dimensions := Get_Value (Child);
+
+                  elsif Tag = "dimIncrement" then
+                     Result.Increment := Get_Value (Child);
+
+                  elsif Tag = "dimIndex" then
+                     declare
+                        Content : constant String := Get_Value (Child);
+                     begin
+                        for J in Content'Range loop
+                           if Content (J) = '-' then
+                              Result.Index := Natural'Value
+                                (Content (Content'First .. J - 1));
+                              goto End_Getting_Index;
+                           end if;
+                        end loop;
+                        Result.Index := 1;
+                        << End_Getting_Index >>
+                     end;
 
                   elsif Tag = "bitOffset"
                     or else Tag = "lsb"
@@ -250,8 +275,59 @@ package body Descriptors.Field is
    is
       use Unbounded, Ada_Gen;
 
+      function Insert_Dimensioned_Fields (Reg_Fields : Field_Vectors.Vector)
+                                         return Field_Vectors.Vector;
+
       function Get_Default (Index : Natural; Size : Natural) return Unsigned;
       --  Retrieves the field default value from the Register's reset value
+
+      -------------------------------
+      -- Insert_Dimensioned_Fields --
+      -------------------------------
+
+      function Insert_Dimensioned_Fields (Reg_Fields : Field_Vectors.Vector)
+                                         return Field_Vectors.Vector
+      is
+         Result : Field_Vectors.Vector;
+      begin
+         Each_Field :
+         for Original of Reg_Fields loop
+
+            Dimensions :
+            for D in 1 .. Original.Dimensions loop
+
+               Replacement :
+               declare
+                  Candidate : Field_T := Original;
+                  Addition : Natural := D - 1;
+                  Index : Natural := Original.Index + Addition;
+                  LSB : Natural := Original.LSB + Original.Increment * Addition;
+                  MSB : Natural := Original.MSB + Original.Increment * Addition;
+               begin
+                  Substitute :
+                  loop
+                     declare
+                        Percent_S : Natural
+                          := Unbounded.Index (Candidate.Name, Pattern => "%s");
+                     begin
+                        exit when Percent_S = 0;
+                        Unbounded.Replace_Slice
+                          (Candidate.Name,
+                           Low  => Percent_S,
+                           High => Percent_S + 1,
+                           By   => Fixed.Trim (Index'Image, Side => Both));
+                     end;
+                     Candidate.LSB := LSB;
+                     Candidate.MSB := MSB;
+                  end loop Substitute;
+                  Result.Append (Candidate);
+               end Replacement;
+
+            end loop Dimensions;
+
+         end loop Each_Field;
+         return Result;
+      end Insert_Dimensioned_Fields;
 
       -----------------
       -- Get_Default --
@@ -293,8 +369,11 @@ package body Descriptors.Field is
       All_RO        : Boolean := True;
       use Descriptors.Register;
 
+      Full_Fields : Field_Vectors.Vector
+        := Insert_Dimensioned_Fields (Reg_Fields);
+
    begin
-      for Field of Reg_Fields loop
+      for Field of Full_Fields loop
          Fields (Field.LSB) := Field;
       end loop;
 

--- a/src/descriptors-field.ads
+++ b/src/descriptors-field.ads
@@ -2,7 +2,7 @@
 --                                                                          --
 --                          SVD Binding Generator                           --
 --                                                                          --
---                    Copyright (C) 2015-2020, AdaCore                      --
+--                    Copyright (C) 2015-2024, AdaCore                      --
 --                                                                          --
 -- SVD2Ada is free software;  you can  redistribute it  and/or modify it    --
 -- under terms of the  GNU General Public License as published  by the Free --
@@ -32,9 +32,24 @@ with Descriptors.Enumerate;
 --  Decodes the <field> elements of the SVD file.
 package Descriptors.Field is
 
+   --  From the SVD, these components are in an optional <dimElementGroup>:
+   --  <dim> specifies the number of array elements,
+   --  <dimIncrement> specifies the address (?bit) offset between consecutive
+   --    array elements,
+   --  (optional) <dimIndex> specifies "a comma seperated list of
+   --    strings being used for identifying each element in the array",
+   --    but we only see r'[0-9]+\-[0-9]+'.
+   --
+   --  We will produce <dim> fields, where %s in the Name translates
+   --  to the first component of <dimIndex> incremented by 1 for each
+   --  field, and LSB, MSB are incremented by <dimIncrement>.
+
    type Field_T is record
       Name             : Unbounded.Unbounded_String;
       Description      : Unbounded.Unbounded_String;
+      Dimensions       : Natural;    -- <dim/>
+      Increment        : Natural;    -- <dimIncrement/>
+      Index            : Natural;    -- first component of <dimIndex/>
       LSB              : Natural;
       MSB              : Natural;
       Size             : Natural;
@@ -48,13 +63,16 @@ package Descriptors.Field is
    function "=" (F1, F2 : Field_T) return Boolean;
 
    Null_Field : constant Field_T :=
-                  (Unbounded.Null_Unbounded_String,
-                   Unbounded.Null_Unbounded_String,
-                   0,
-                   0,
-                   0,
-                   Read_Write,
-                   others => <>);
+     (Name        => Unbounded.Null_Unbounded_String,
+      Description => Unbounded.Null_Unbounded_String,
+      Dimensions  => 0,
+      Increment   => 0,
+      Index       => 0,
+      LSB         => 0,
+      MSB         => 0,
+      Size        => 0,
+      Acc         => Read_Write,
+      others      => <>);
 
    package Field_Vectors is new Ada.Containers.Vectors
      (Positive, Field_T);

--- a/svd2ada.gpr
+++ b/svd2ada.gpr
@@ -79,4 +79,10 @@ project SVD2ada is
       for Switches ("Ada") use ("-Es"); --  Symbolic traceback
    end Binder;
 
+   package Install is
+      for Mode use "usage";
+      for Required_Artifacts ("schema") use ("schema/");
+      for Required_Artifacts ("share/CMSIS-SVD") use ("CMSIS-SVD/");
+   end Install;
+
 end SVD2ada;


### PR DESCRIPTION
I would have put this in as 3 separate PRs, but they would need to be implemented in the right order, because the way that CI had been set up meant that CI failed.

Next, arrange that `alr install` installs the schema and SVDs, so that they’re accessible on the user’s computer.

Next (the main event), fix the problem raised in issues #100, #102, #106, where register fields with `%s` (and a `<dim>` tag, hence "dimensioned") weren’t properly translated.